### PR TITLE
utf-8 search index support and build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 
 .idea
 .vscode
+/**/.settings
+/**/.mvn
+.classpath
+.project
 target
 node_modules
 td-documentation-reactjs/build

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,17 @@
                         </execution>
 
                         <execution>
+                            <id>npm install</id>
+                            <goals>
+                                <goal>npm</goal>
+                            </goals>
+                            <phase>generate-resources</phase>
+                            <configuration>
+                                <arguments>install</arguments>
+                            </configuration>
+                        </execution>
+
+                        <execution>
                             <id>Frontend production build</id>
                             <phase>generate-resources</phase>
                             <goals>

--- a/td-documentation-reactjs/package.json
+++ b/td-documentation-reactjs/package.json
@@ -57,7 +57,7 @@
     "query-string": "^4.3.1",
     "react": "^15.6.0",
     "react-dom": "^15.6.0",
-    "semantic-ui": "^2.2.7",
+    "semantic-ui-css": "^2.2.7",
     "victory": "^0.21.1",
     "victory-chart": "^21.1.4"
   },

--- a/td-documentation-reactjs/src/doc-elements/code-snippets/CodeSnippetWithInlineComments.js
+++ b/td-documentation-reactjs/src/doc-elements/code-snippets/CodeSnippetWithInlineComments.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import 'semantic-ui/dist/components/label.css'
+import 'semantic-ui-css/components/label.css'
 
 import SimpleCodeToken from './SimpleCodeToken.js'
 import {splitTokensIntoLines, isInlinedComment, trimComment, containsInlinedComment} from './codeUtils'

--- a/td-documentation-reactjs/src/doc-elements/table/Table.js
+++ b/td-documentation-reactjs/src/doc-elements/table/Table.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import './Table.css'
-import 'semantic-ui/dist/components/table.min.css'
+import 'semantic-ui-css/components/table.min.css'
 
 const Table = ({table, ...props}) => {
     const Row = ({row}) => {

--- a/td-documentation/src/main/java/com/twosigma/documentation/html/Deployer.java
+++ b/td-documentation/src/main/java/com/twosigma/documentation/html/Deployer.java
@@ -1,6 +1,7 @@
 package com.twosigma.documentation.html;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -9,6 +10,7 @@ import java.util.Set;
 
 import com.twosigma.console.ConsoleOutputs;
 import com.twosigma.console.ansi.Color;
+
 import org.apache.commons.io.FileUtils;
 
 /**
@@ -28,11 +30,11 @@ public class Deployer {
     }
 
     public void deploy(String relativePath, String content) {
-        deploy(Paths.get(relativePath), content.getBytes());
+        deploy(Paths.get(relativePath), content);
     }
 
     public void deploy(Path relativePath, String content) {
-        deploy(relativePath, content.getBytes());
+        deploy(relativePath, content.getBytes(StandardCharsets.UTF_8));
     }
 
     public void deploy(Path srcPath) {

--- a/td-testing-webtau-reactjs/.storybook/config.js
+++ b/td-testing-webtau-reactjs/.storybook/config.js
@@ -1,4 +1,4 @@
-import { configure } from '@kadira/storybook';
+import { configure } from '@storybook/react';
 
 function loadStories() {
   require('../src/report');

--- a/td-testing-webtau-reactjs/package.json
+++ b/td-testing-webtau-reactjs/package.json
@@ -7,8 +7,8 @@
     "react-dom": "^15.5.4"
   },
   "devDependencies": {
-    "react-scripts": "1.0.7",
-    "@kadira/storybook": "^2.21.0"
+    "@storybook/react": "^3.1.9",
+    "react-scripts": "1.0.10"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/td-testing-webtau-reactjs/src/report/index.js
+++ b/td-testing-webtau-reactjs/src/report/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { storiesOf } from '@kadira/storybook'
+import { storiesOf } from '@storybook/react'
 
 import StepsDemo from './StepsDemo'
 import WebTauReportDemo from './WebTauReportDemo'


### PR DESCRIPTION
- fixes bug that causes utf-8 characters to be smushed during deployment, which breaks search-indexes sometimes
- fixes build bugs all over the codebase, you can now git clone && mvn pacakage without any errors in any of the pacakages.

Signed-off-by: Jim Hughes <james.l.hughes@outlook.com>