### PR TITLE
Fix for local file links not always working

### DIFF
--- a/td-documentation/src/main/java/com/twosigma/documentation/website/WebSite.java
+++ b/td-documentation/src/main/java/com/twosigma/documentation/website/WebSite.java
@@ -348,7 +348,9 @@ public class WebSite {
             Set<TocItem> tocItems = tocItemsByAuxiliaryFilePath.computeIfAbsent(af.getPath(), k -> new HashSet<>());
             tocItems.add(tocItem);
 
-            auxiliaryFiles.put(af.getPath(), af);
+            if (!auxiliaryFiles.containsKey(af.getPath()) || !auxiliaryFiles.get(af.getPath()).isDeploymentRequired()) {
+                auxiliaryFiles.put(af.getPath(), af);
+            }
             if (auxiliaryFileListener != null) {
                 auxiliaryFileListener.onAuxiliaryFile(af);
             }


### PR DESCRIPTION
In the auxilaryFiles map we blidnly override existing entries.  Therefore if early on you reference a swagger file for example, as a local link, and then you do open api spec references, the second reference will override the first.  The first has isDeploymentRequired set to true, the second to false and consequently the file does not get deployed.

I didn't create a test because testing WebSite seems like it would require a **lot** of setup.