### PR TITLE
force page section selection on click

### DIFF
--- a/td-documentation-reactjs/public/toc.js
+++ b/td-documentation-reactjs/public/toc.js
@@ -89,6 +89,10 @@ toc = [
           {
             "title": "Preview",
             "id": "preview"
+          },
+          {
+            "title": "Deploy",
+            "id": "deploy"
           }
         ]
       }
@@ -162,6 +166,10 @@ toc = [
           {
             "title": "Links",
             "id": "links"
+          },
+          {
+            "title": "Downloads",
+            "id": "downloads"
           }
         ]
       },
@@ -304,11 +312,7 @@ toc = [
       {
         "sectionTitle": "Snippets",
         "pageTitle": "Java",
-        "pageMeta": {
-          "type": [
-            "api"
-          ]
-        },
+        "pageMeta": {},
         "fileName": "java",
         "dirName": "snippets",
         "pageSectionIdTitles": [
@@ -381,6 +385,27 @@ toc = [
       },
       {
         "sectionTitle": "Snippets",
+        "pageTitle": "Typescript",
+        "pageMeta": {},
+        "fileName": "typescript",
+        "dirName": "snippets",
+        "pageSectionIdTitles": [
+          {
+            "title": "Parsing",
+            "id": "parsing"
+          },
+          {
+            "title": "Properties",
+            "id": "properties"
+          },
+          {
+            "title": "JSX Elements",
+            "id": "jsx-elements"
+          }
+        ]
+      },
+      {
+        "sectionTitle": "Snippets",
         "pageTitle": "Cpp",
         "pageMeta": {},
         "fileName": "cpp",
@@ -404,8 +429,99 @@ toc = [
             "id": "paths"
           },
           {
+            "title": "Paths From File",
+            "id": "paths-from-file"
+          },
+          {
+            "title": "Json Subparts",
+            "id": "json-subparts"
+          },
+          {
+            "title": "Title",
+            "id": "title"
+          },
+          {
+            "title": "Read More",
+            "id": "read-more"
+          },
+          {
+            "title": "Highlights",
+            "id": "highlights"
+          },
+          {
             "title": "Test Results",
             "id": "test-results"
+          }
+        ]
+      },
+      {
+        "sectionTitle": "Snippets",
+        "pageTitle": "Api Parameters",
+        "pageMeta": {},
+        "fileName": "api-parameters",
+        "dirName": "snippets",
+        "pageSectionIdTitles": [
+          {
+            "title": "Inlined CSV",
+            "id": "inlined-csv"
+          }
+        ]
+      },
+      {
+        "sectionTitle": "Snippets",
+        "pageTitle": "Open API",
+        "pageMeta": {},
+        "fileName": "open-API",
+        "dirName": "snippets",
+        "pageSectionIdTitles": [
+          {
+            "title": "Operation definition",
+            "id": "operation-definition"
+          },
+          {
+            "title": "Auto Section",
+            "id": "auto-section"
+          },
+          {
+            "title": "Time Estimates",
+            "id": "time-estimates"
+          },
+          {
+            "title": "Tags",
+            "id": "tags"
+          },
+          {
+            "title": "Price Estimates",
+            "id": "price-estimates"
+          },
+          {
+            "title": "Time Estimates",
+            "id": "time-estimates"
+          }
+        ]
+      },
+      {
+        "sectionTitle": "Snippets",
+        "pageTitle": "Jupyter Notebook",
+        "pageMeta": {},
+        "fileName": "jupyter-notebook",
+        "dirName": "snippets",
+        "pageSectionIdTitles": [
+          {
+            "title": "Code and Output",
+            "id": "code-and-output"
+          },
+          {
+            "title": "Seamless Markdown Integration",
+            "id": "seamless-markdown-integration"
+          },
+          {
+            "title": "Pandas",
+            "id": "pandas"
+          },
+          {
+            "title": "Two Sides",
+            "id": "two-sides"
           }
         ]
       },
@@ -431,19 +547,6 @@ toc = [
           {
             "title": "Presentation mode",
             "id": "presentation-mode"
-          }
-        ]
-      },
-      {
-        "sectionTitle": "Snippets",
-        "pageTitle": "Open API",
-        "pageMeta": {},
-        "fileName": "open-API",
-        "dirName": "snippets",
-        "pageSectionIdTitles": [
-          {
-            "title": "Operation definition",
-            "id": "operation-definition"
           }
         ]
       },
@@ -616,6 +719,81 @@ toc = [
           {
             "title": "Loops",
             "id": "loops"
+          }
+        ]
+      },
+      {
+        "sectionTitle": "Layout",
+        "pageTitle": "Two Sides Pages",
+        "pageMeta": {
+          "type": [
+            "two-sides"
+          ]
+        },
+        "fileName": "two-sides-pages",
+        "dirName": "layout",
+        "pageSectionIdTitles": [
+          {
+            "title": "Setup",
+            "id": "setup"
+          },
+          {
+            "title": "Details Side",
+            "id": "details-side"
+          },
+          {
+            "title": "Open API example",
+            "id": "open-api-example"
+          }
+        ]
+      },
+      {
+        "sectionTitle": "Layout",
+        "pageTitle": "Two Sides Tabs",
+        "pageMeta": {
+          "type": [
+            "two-sides"
+          ]
+        },
+        "fileName": "two-sides-tabs",
+        "dirName": "layout",
+        "pageSectionIdTitles": [
+          {
+            "title": "Unified Tabs",
+            "id": "unified-tabs"
+          },
+          {
+            "title": "Definition",
+            "id": "definition"
+          },
+          {
+            "title": "Markdown Per Tab",
+            "id": "markdown-per-tab"
+          }
+        ]
+      },
+      {
+        "sectionTitle": "Layout",
+        "pageTitle": "Jupyter Notebook Two Sides",
+        "pageMeta": {
+          "type": [
+            "two-sides"
+          ]
+        },
+        "fileName": "jupyter-notebook-two-sides",
+        "dirName": "layout",
+        "pageSectionIdTitles": [
+          {
+            "title": "Code First",
+            "id": "code-first"
+          },
+          {
+            "title": "Story First",
+            "id": "story-first"
+          },
+          {
+            "title": "Pandas",
+            "id": "pandas"
           }
         ]
       }

--- a/td-documentation-reactjs/src/doc-elements/DocumentationLayout.js
+++ b/td-documentation-reactjs/src/doc-elements/DocumentationLayout.js
@@ -23,6 +23,7 @@ class DocumentationLayout extends Component {
             toc,
             onHeaderClick,
             onTocItemClick,
+            onTocItemPageSectionClick,
             onNextPage,
             onPrevPage,
             textSelection,
@@ -46,6 +47,7 @@ class DocumentationLayout extends Component {
                               selectedItem={selectedTocItem}
                               onHeaderClick={onHeaderClick}
                               onTocItemClick={onTocItemClick}
+                              onTocItemPageSectionClick={onTocItemPageSectionClick}
                               onNextPage={onNextPage}
                               onPrevPage={onPrevPage}/>
                 </div>

--- a/td-documentation-reactjs/src/doc-elements/structure/TocMenu.js
+++ b/td-documentation-reactjs/src/doc-elements/structure/TocMenu.js
@@ -2,14 +2,20 @@ import React, {PureComponent} from 'react'
 import {documentationNavigation} from '../structure/DocumentationNavigation'
 import {pageTypesRegistry} from '../page/PageTypesRegistry'
 
-const PageSections = ({pageSectionIdTitles, selected}) => {
+const PageSections = ({pageSectionIdTitles, selected, onTocItemPageSectionClick}) => {
     return (<div className="page-sections">
         {pageSectionIdTitles.map((idTitle, idx) => {
+            const onClick = (e) => { e.preventDefault(); onTocItemPageSectionClick(idTitle.id) }
+
             const isSelected = idTitle.id === selected.pageSectionId
             const className = "page-section" + (isSelected ? " selected" : "")
             const href = "#" + idTitle.id
 
-            return (<div className={className} key={idx}><a href={href}>{idTitle.title}</a></div>)
+            return (
+                <div className={className} key={idx} onClick={onClick}>
+                    <a href={href}>{idTitle.title}</a>
+                </div>
+            )
         })
         }
     </div>)
@@ -17,18 +23,21 @@ const PageSections = ({pageSectionIdTitles, selected}) => {
 
 class Item extends PureComponent {
     render() {
-        const {item, selected, isSelected, onClickHandler} = this.props
+        const {item, selected, isSelected, onTocItemClick, onTocItemPageSectionClick} = this.props
 
         const className = 'toc-item' + (isSelected ? ' selected' : '')
         const href = documentationNavigation.buildUrl(item)
 
         const displayPageSections = isSelected && pageTypesRegistry.expandToc(item)
 
+        const onClick = (e) => { e.preventDefault(); onTocItemClick(item.dirName, item.fileName)}
+
         return (
             <div className={className} ref={this.saveNodeRef}>
-                <a href={href} onClick={ (e) => { e.preventDefault(); onClickHandler(item.dirName, item.fileName)}}>{item.pageTitle}</a>
+                <a href={href} onClick={onClick}>{item.pageTitle}</a>
                 {displayPageSections && <PageSections pageSectionIdTitles={item.pageSectionIdTitles}
-                                                      selected={selected}/>}
+                                                      selected={selected}
+                                                      onTocItemPageSectionClick={onTocItemPageSectionClick}/>}
             </div>
         )
     }
@@ -54,7 +63,7 @@ class Item extends PureComponent {
     }
 }
 
-const Section = ({section, selected, onClickHandler}) => {
+const Section = ({section, selected, onTocItemClick, onTocItemPageSectionClick}) => {
     const className = 'toc-section' + (section.dirName === selected.dirName ? ' selected' : '')
 
     return (
@@ -64,12 +73,13 @@ const Section = ({section, selected, onClickHandler}) => {
                                                item={item}
                                                selected={selected}
                                                isSelected={item.dirName === selected.dirName && item.fileName === selected.fileName}
-                                               onClickHandler={onClickHandler} />)}
+                                               onTocItemClick={onTocItemClick}
+                                               onTocItemPageSectionClick={onTocItemPageSectionClick}/>)}
         </div>
     )
 }
 
-const TocMenu = ({toc, selected, onClickHandler}) => {
+const TocMenu = ({toc, selected, onTocItemClick, onTocItemPageSectionClick}) => {
     selected = selected || {dirName: "", fileName: ""}
 
     // we won't render items that don't belong to a section. it includes things like top index.html or other misc files
@@ -78,7 +88,8 @@ const TocMenu = ({toc, selected, onClickHandler}) => {
             {toc.filter(sectionEntry => sectionEntry.dirName.length > 0).map((sectionEntry) =>
                 <Section key={sectionEntry.sectionTitle}
                          selected={selected}
-                         onClickHandler={onClickHandler}
+                         onTocItemClick={onTocItemClick}
+                         onTocItemPageSectionClick={onTocItemPageSectionClick}
                          section={sectionEntry} />)}
         </div>
     )

--- a/td-documentation-reactjs/src/doc-elements/structure/TocPanel.js
+++ b/td-documentation-reactjs/src/doc-elements/structure/TocPanel.js
@@ -11,6 +11,7 @@ class TocPanel extends Component {
             selected,
             selectedItem,
             onTocItemClick,
+            onTocItemPageSectionClick,
             onHeaderClick} = this.props
 
         const panelClass = "toc-panel" + (collapsed ? " collapsed" : "") + (selected ? " selected" : "")
@@ -27,7 +28,8 @@ class TocPanel extends Component {
                 </div>
                 <TocMenu toc={toc}
                          selected={selectedItem}
-                         onClickHandler={onTocItemClick}/>
+                         onTocItemPageSectionClick={onTocItemPageSectionClick}
+                         onTocItemClick={onTocItemClick}/>
             </div>
         )
     }


### PR DESCRIPTION
for short pages auto section highlight prevents from visually selecting
page section on click.
if you click on page section in TOC it will stick to that selection
as long as the title is visible.

toc.js is updated for local testing in dev mode