### PR TITLE
deploy auxiliary files during preview. timestamp for images in preview

### DIFF
--- a/td-documentation-core/src/main/java/com/twosigma/documentation/core/AuxiliaryFilesRegistry.java
+++ b/td-documentation-core/src/main/java/com/twosigma/documentation/core/AuxiliaryFilesRegistry.java
@@ -8,25 +8,34 @@ import java.util.stream.Stream;
 
 public class AuxiliaryFilesRegistry {
     private final Map<Path, Set<TocItem>> tocItemsByAuxiliaryFilePath;
+    private final Map<TocItem, Set<AuxiliaryFile>> auxiliaryFilesByTocItem;
     private final Map<Path, AuxiliaryFile> auxiliaryFiles;
     private final Set<AuxiliaryFileListener> auxiliaryFileListeners;
 
     public AuxiliaryFilesRegistry() {
         this.tocItemsByAuxiliaryFilePath = new HashMap<>();
+        this.auxiliaryFilesByTocItem = new HashMap<>();
         this.auxiliaryFiles = new HashMap<>();
         this.auxiliaryFileListeners = new HashSet<>();
     }
 
-    public Set<TocItem> tocItemsForPath(Path auxiliaryFile) {
+    public Set<TocItem> tocItemsByPath(Path auxiliaryFile) {
         return tocItemsByAuxiliaryFilePath.getOrDefault(auxiliaryFile, Collections.emptySet());
+    }
+
+    public Set<AuxiliaryFile> auxiliaryFilesByTocItem(TocItem tocItem) {
+        return auxiliaryFilesByTocItem.get(tocItem);
     }
 
     public void updateFileAssociations(TocItem tocItem, AuxiliaryFile auxiliaryFile) {
         Set<TocItem> tocItems = tocItemsByAuxiliaryFilePath.computeIfAbsent(auxiliaryFile.getPath(), k -> new HashSet<>());
         tocItems.add(tocItem);
 
-        if (!auxiliaryFiles.containsKey(auxiliaryFile.getPath()) || !auxiliaryFiles.get(auxiliaryFile.getPath()).isDeploymentRequired()) {
-            auxiliaryFiles.put(auxiliaryFile.getPath(), auxiliaryFile);
+        Set<AuxiliaryFile> filesForTocItem = auxiliaryFilesByTocItem.computeIfAbsent(tocItem, k -> new HashSet<>());
+        filesForTocItem.add(auxiliaryFile);
+
+        if (!this.auxiliaryFiles.containsKey(auxiliaryFile.getPath()) || !this.auxiliaryFiles.get(auxiliaryFile.getPath()).isDeploymentRequired()) {
+            this.auxiliaryFiles.put(auxiliaryFile.getPath(), auxiliaryFile);
         }
 
         auxiliaryFileListeners.forEach(listener -> listener.onAuxiliaryFile(auxiliaryFile));

--- a/td-documentation-core/src/main/java/com/twosigma/documentation/parser/docelement/DocElementCreationParserHandler.java
+++ b/td-documentation-core/src/main/java/com/twosigma/documentation/parser/docelement/DocElementCreationParserHandler.java
@@ -239,6 +239,7 @@ public class DocElementCreationParserHandler implements ParserHandler {
                 "destination", docStructure.fullUrl(auxiliaryFile.getDeployRelativePath().toString()),
                 "alt", alt,
                 "inlined", true,
+                "timestamp", System.currentTimeMillis(),
                 "width", image.getWidth(),
                 "height", image.getHeight());
 

--- a/td-documentation-core/src/test/groovy/com/twosigma/documentation/AuxiliaryFilesRegistryTest.groovy
+++ b/td-documentation-core/src/test/groovy/com/twosigma/documentation/AuxiliaryFilesRegistryTest.groovy
@@ -28,4 +28,25 @@ class AuxiliaryFilesRegistryTest {
         registry.updateFileAssociations(tocItem, afNotRequiringDeployment)
         pathAssertions()
     }
+
+    @Test
+    void "maintains dependency between tocitem and auxiliary files"() {
+        def registry = new AuxiliaryFilesRegistry()
+
+        def tocItemA = new TocItem("chapter-a", "page-one")
+        def tocItemB = new TocItem("chapter-b", "page-two")
+
+        registry.updateFileAssociations(tocItemA, AuxiliaryFile.builtTime(Paths.get('/root/a1')))
+        registry.updateFileAssociations(tocItemA, AuxiliaryFile.builtTime(Paths.get('/root/a2')))
+        registry.updateFileAssociations(tocItemB, AuxiliaryFile.builtTime(Paths.get('/root/b1')))
+        registry.updateFileAssociations(tocItemB, AuxiliaryFile.builtTime(Paths.get('/root/b2')))
+
+        def auxiliaryFilesA = registry.auxiliaryFilesByTocItem(new TocItem("chapter-a", "page-one"))
+        auxiliaryFilesA.path.size().should == 2
+        auxiliaryFilesA.path*.toString().sort().should == ['/root/a1', '/root/a2']
+
+        def auxiliaryFilesB = registry.auxiliaryFilesByTocItem(new TocItem("chapter-b", "page-two"))
+        auxiliaryFilesB.path.size().should == 2
+        auxiliaryFilesB.path*.toString().sort().should == ['/root/b1', '/root/b2']
+    }
 }

--- a/td-documentation-reactjs/src/doc-elements/images/AnnotatedImage.js
+++ b/td-documentation-reactjs/src/doc-elements/images/AnnotatedImage.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react'
 
-import {isPreviewEnabled} from '../docMeta'
+import {imageAdditionalPreviewUrlParam} from './imagePreviewAdditionalUrlParam'
+
 import './AnnotatedImage.css'
 
 class AnnotatedImage extends Component {
@@ -9,7 +10,18 @@ class AnnotatedImage extends Component {
     }
 
     render() {
-        const {imageSrc, annotations, width, height, isStatic, selectedId, caption, captionBottom, fit} = this.props
+        const {
+            imageSrc,
+            annotations,
+            width,
+            height,
+            isStatic,
+            selectedId,
+            caption,
+            captionBottom,
+            fit,
+            timestamp
+        } = this.props
 
         const scale = fit ? 900.0/width : 1 // TODO theme with sizes. How to share with CSS, e.g. content-block?
 
@@ -32,7 +44,8 @@ class AnnotatedImage extends Component {
         return (
             <div style={parentStyle} className="annotated-image" >
                 <div style={imageContainerStyle}>
-                    <img alt="annotated" src={imageSrc}
+                    <img alt="annotated"
+                         src={imageSrc + imageAdditionalPreviewUrlParam(timestamp)}
                          width={imageWidth}
                          height={imageHeight}
                          ref={node => this.imageNode = node}/>

--- a/td-documentation-reactjs/src/doc-elements/images/Image.js
+++ b/td-documentation-reactjs/src/doc-elements/images/Image.js
@@ -1,12 +1,17 @@
 import React from 'react'
+import {imageAdditionalPreviewUrlParam} from './imagePreviewAdditionalUrlParam'
 
-const Image = ({destination, inlined, isNarrow}) => {
+const Image = ({destination, inlined, isNarrow, timestamp}) => {
     const className = "image" + (inlined ? " inlined" : "")
         + (isNarrow ? " content-block" : "")
 
-    const alt = `image ${destination} not found`
+    const alt = `image ${destination} was not found`
 
-    return (<div className={className}><img alt={alt} src={destination}/></div>)
+    return (
+        <div className={className}>
+            <img alt={alt} src={destination + imageAdditionalPreviewUrlParam(timestamp)}/>
+        </div>
+    )
 }
 
 export default Image

--- a/td-documentation-reactjs/src/doc-elements/images/imagePreviewAdditionalUrlParam.js
+++ b/td-documentation-reactjs/src/doc-elements/images/imagePreviewAdditionalUrlParam.js
@@ -1,0 +1,7 @@
+import {isPreviewEnabled} from '../docMeta'
+
+export function imageAdditionalPreviewUrlParam(timestamp) {
+    return isPreviewEnabled() && timestamp ?
+        '?timestamp=' + timestamp:
+        ''
+}

--- a/td-documentation/src/main/java/com/twosigma/documentation/extensions/image/ImageIncludePlugin.java
+++ b/td-documentation/src/main/java/com/twosigma/documentation/extensions/image/ImageIncludePlugin.java
@@ -59,6 +59,8 @@ public class ImageIncludePlugin implements IncludePlugin {
         Map<String, Object> props = new LinkedHashMap<>(pluginParams.getOpts().toMap());
         props.put("imageSrc", docStructure.fullUrl(auxiliaryFile.getDeployRelativePath().toString()));
 
+        props.put("timestamp", System.currentTimeMillis());
+
         props.put("shapes", annotations != null ? annotations.get("shapes") : Collections.emptyList());
         setWidthHeight(props, scaleRatio, annotations, imagePath);
 


### PR DESCRIPTION
When auxiliary file is missing or changed it will be deployed.
During preview images are going to have timestamp url param to bypass cache on file changes.