### PR TITLE
Add shaded version of maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>td-documentation-cli</module>
         <module>td-documentation-generators</module>
         <module>td-documentation-maven-plugin</module>
+        <module>td-documentation-maven-plugin-shaded</module>
         <module>td-documentation-docs</module>
         <module>td-ts-dist</module>
         <module>td-ts-ddjt</module>

--- a/td-documentation-maven-plugin-shaded/pom.xml
+++ b/td-documentation-maven-plugin-shaded/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.twosigma.td</groupId>
+        <artifactId>td-parent</artifactId>
+        <version>0.0.1</version>
+    </parent>
+
+    <artifactId>td-documentation-maven-plugin-shaded</artifactId>
+
+    <packaging>maven-plugin</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.twosigma.td</groupId>
+            <artifactId>td-documentation-maven-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.5.2</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/groovy</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addSources</goal>
+                            <goal>compile</goal>
+                            <goal>generateStubs</goal>
+                            <goal>addTestSources</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.5.1</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/td-documentation-maven-plugin-shaded/src/main/groovy/com/twosigma/documentation/maven/ShadedMDocMavenBuildRunner.groovy
+++ b/td-documentation-maven-plugin-shaded/src/main/groovy/com/twosigma/documentation/maven/ShadedMDocMavenBuildRunner.groovy
@@ -1,0 +1,7 @@
+package com.twosigma.documentation.maven
+
+import org.apache.maven.plugins.annotations.LifecyclePhase
+import org.apache.maven.plugins.annotations.Mojo
+
+@Mojo(name = "build", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
+class ShadedMDocMavenBuildRunner extends MDocMavenBuildRunner {}

--- a/td-documentation-maven-plugin-shaded/src/main/groovy/com/twosigma/documentation/maven/ShadedMDocMavenPreviewRunner.groovy
+++ b/td-documentation-maven-plugin-shaded/src/main/groovy/com/twosigma/documentation/maven/ShadedMDocMavenPreviewRunner.groovy
@@ -1,0 +1,7 @@
+package com.twosigma.documentation.maven
+
+import org.apache.maven.plugins.annotations.Mojo
+
+@Mojo(name = "preview")
+class ShadedMDocMavenPreviewRunner extends MDocMavenPreviewRunner {
+}


### PR DESCRIPTION
This is temporary to make it easier to get just the plugin into a private Maven repo.  Once MDoc is OSS and in Maven Central this can go away.