### PR TITLE
Fix cross-page link validation

### DIFF
--- a/td-documentation/src/main/java/com/twosigma/documentation/website/WebSiteDocStructure.java
+++ b/td-documentation/src/main/java/com/twosigma/documentation/website/WebSiteDocStructure.java
@@ -126,6 +126,10 @@ class WebSiteDocStructure implements DocStructure {
             return Optional.empty();
         }
 
+        if (tocItem.hasPageSection(anchorId)) {
+            return Optional.empty();
+        }
+
         return Optional.of(validationMessage.get());
     }
 

--- a/td-documentation/src/test/groovy/com/twosigma/documentation/website/WebSiteDocStructureTest.groovy
+++ b/td-documentation/src/test/groovy/com/twosigma/documentation/website/WebSiteDocStructureTest.groovy
@@ -1,5 +1,6 @@
 package com.twosigma.documentation.website
 
+import com.twosigma.documentation.parser.PageSectionIdTitle
 import com.twosigma.documentation.structure.DocMeta
 import com.twosigma.documentation.structure.DocUrl
 import com.twosigma.documentation.structure.TableOfContents
@@ -24,6 +25,8 @@ class WebSiteDocStructureTest {
 
         toc = new TableOfContents('md')
         toc.addTocItem('chapter', 'page')
+        toc.addTocItem('chapter', 'pageTwo')
+        toc.findTocItem('chapter', 'pageTwo').pageSectionIdTitles = [new PageSectionIdTitle ('Test Section')]
     }
 
     @Before
@@ -38,6 +41,7 @@ class WebSiteDocStructureTest {
         docStructure.registerLocalAnchor(path, 'localId')
         docStructure.validateUrl(path, 'section title', new DocUrl('chapter/page#functionRefId'))
         docStructure.validateUrl(path, 'section title', new DocUrl('chapter/page#localId'))
+        docStructure.validateUrl(path, 'section title', new DocUrl('chapter/pageTwo#test-section'))
         docStructure.validateCollectedLinks()
     }
 


### PR DESCRIPTION
Without the fix in `WebSiteDocStructure`, the test I added failed.  With this in place the test passes and my docs also generate successfully.