### PR TITLE
support escaping name in api-parameters. This is mainly useful to support java class with packages.

### DIFF
--- a/znai/src/main/java/com/twosigma/znai/extensions/api/ApiParametersCsvParser.java
+++ b/znai/src/main/java/com/twosigma/znai/extensions/api/ApiParametersCsvParser.java
@@ -58,9 +58,11 @@ public class ApiParametersCsvParser {
         MarkupParserResult markupParserResult = markupParser.parse(path, row.get(2));
         List<Map<String, Object>> description = markupParserResult.getDocElement().contentToListOfMaps();
 
-        if (name.contains(".") && !name.contains("..")) {
+        boolean escapedName = name.startsWith("'") && name.endsWith("'");
+        if (name.contains(".") && !name.contains("..") && !escapedName) {
             addNested(name, type, description);
         } else {
+            name = escapedName ? name.substring(1, name.length()-1) : name;
             apiParameters.add(name, type, description);
         }
     }

--- a/znai/src/test/groovy/com/twosigma/znai/extensions/api/ApiParametersCsvParserTest.groovy
+++ b/znai/src/test/groovy/com/twosigma/znai/extensions/api/ApiParametersCsvParserTest.groovy
@@ -34,6 +34,7 @@ nested.subNested.url, String, nested nested 1
 nested.subNested.fileName, String, nested nested 2
 nestedList, array of objects, descr5
 nestedList.score, int, descr6
+'escaped.name', String, desc7
 """)
 
         apiParameters.toMap().should equal([parameters: [
@@ -45,6 +46,8 @@ nestedList.score, int, descr6
                                  [[name: 'url', type: 'String', description: [[markdown: 'nested nested 1', type: 'TestMarkdown']]],
                                   [name: 'fileName', type: 'String', description: [[markdown: 'nested nested 2', type: 'TestMarkdown']]]]]]],
                 [name: 'nestedList', type: 'array of objects', description: [[markdown: 'descr5', type: 'TestMarkdown']], children: [
-                        [name: 'score', type: 'int', description: [[markdown: 'descr6', type: 'TestMarkdown']]]]]]])
+                        [name: 'score', type: 'int', description: [[markdown: 'descr6', type: 'TestMarkdown']]]]],
+                [name: 'escaped.name', type: 'String', description: [[markdown: 'desc7', type: 'TestMarkdown']]]
+        ]])
     }
 }


### PR DESCRIPTION
I want to define an api parameters like

    'foo.bar.Baz', object, description