### PR TITLE
fix linking to root of a documentation with an anchor

### DIFF
--- a/znai-core/src/main/java/org/testingisdocumenting/znai/structure/DocUrl.java
+++ b/znai-core/src/main/java/org/testingisdocumenting/znai/structure/DocUrl.java
@@ -17,8 +17,10 @@
 package org.testingisdocumenting.znai.structure;
 
 public class DocUrl {
-    private static final String LINK_TO_SECTION_INSTRUCTION = "To refer to a section of this document use" +
-            " dir-name/file-name[#page-section-id]. Use #page-section-id to refer to the current page section";
+    private static final String LINK_TO_SECTION_INSTRUCTION = "To refer to a section of a document page use " +
+            " dir-name/file-name-without-extension#page-section-id. #page-section-id is optional.\n" +
+            "Use #page-section-id to refer to the current page section.\n" +
+            "Use /#section-id to refer the root page of a documentation.\n";
 
     private String dirName = "";
     private String fileName = "";
@@ -64,6 +66,13 @@ public class DocUrl {
     }
 
     private boolean handleIndex() {
+        if (url.startsWith("/#")) {
+            isIndexUrl = true;
+            anchorId = url.substring(2);
+
+            return true;
+        }
+
         return isIndexUrl = url.equals("/");
     }
 

--- a/znai-docs/znai/flow/page-references.md
+++ b/znai-docs/znai/flow/page-references.md
@@ -39,7 +39,7 @@ Use [Subsection Shortcut](#links) if a subsection is within the same page:
   
 ## Index Page
 
-Clicking this [index page](ad/) link will have the same effect as clicking the documentation title at the top of the **Navigation Panel**
+Clicking this [index page](/) link will have the same effect as clicking the documentation title at the top of the **Navigation Panel**
 
 To refer back to the top-level `index` page use:   
 

--- a/znai-docs/znai/flow/page-references.md
+++ b/znai-docs/znai/flow/page-references.md
@@ -5,7 +5,7 @@ Links to navigate to the next page are at the end of each page.
 
 Create links to remind users of *essential* concepts introduced previously. There is a good chance that a reader skipped over these or forgot about them. 
 
-Avoid: links that navigate users forward. It breaks the flow of a documentation. 
+Avoid: links that navigate users forward. It may break the flow of a documentation. 
 
 # Links
 
@@ -23,18 +23,12 @@ To refer `internal` page within your documentation use:
 
 Note: you can get `page-section-id` by hovering over a section title and pressing link icon. Your browser URL display the updated link.
 
-To refer back to the top-level `index` page use:   
-
-```markdown
-[index link](/)
-```
-
 ## Links to Subsection
 
 Linking to subsections is the same as linking to a top level section. [Here is an example](flow/page-references#links-to-subsection)
 
 ```markdown
-[Here is an example](flow/page-references#links-to-subsection)
+[Here is an example](flow/page-references#link-to-subsection)
 ```
 
 Use [Subsection Shortcut](#links) if a subsection is within the same page: 
@@ -45,7 +39,14 @@ Use [Subsection Shortcut](#links) if a subsection is within the same page:
   
 ## Index Page
 
-Clicking this [index page](/) link will have the same effect as clicking the documentation title at the top of the **Navigation Panel**
+Clicking this [index page](ad/) link will have the same effect as clicking the documentation title at the top of the **Navigation Panel**
+
+To refer back to the top-level `index` page use:   
+
+```markdown
+[index page](/)
+[index page](/#link-to-subsection)
+```
 
 # Downloads
 

--- a/znai/src/main/java/org/testingisdocumenting/znai/website/WebSiteDocStructure.java
+++ b/znai/src/main/java/org/testingisdocumenting/znai/website/WebSiteDocStructure.java
@@ -80,7 +80,7 @@ class WebSiteDocStructure implements DocStructure {
 
     @Override
     public void validateUrl(Path path, String additionalClue, DocUrl docUrl) {
-        if (docUrl.isExternalUrl() || docUrl.isIndexUrl()) {
+        if (docUrl.isExternalUrl()) {
             return;
         }
 
@@ -94,7 +94,7 @@ class WebSiteDocStructure implements DocStructure {
         }
 
         if (docUrl.isIndexUrl()) {
-            return "/" + docMeta.getId();
+            return "/" + docMeta.getId() + (docUrl.getAnchorId().isEmpty() ? "" : docUrl.getAnchorIdWithHash());
         }
 
         return fullUrl(createUrlBase(path, docUrl) + docUrl.getAnchorIdWithHash());
@@ -147,9 +147,8 @@ class WebSiteDocStructure implements DocStructure {
     private Optional<String> validateLink(LinkToValidate link) {
         String anchorId = link.docUrl.getAnchorId();
 
-        TocItem tocItem = link.docUrl.isAnchorOnly() ?
-                parsingConfiguration.tocItemByPath(componentsRegistry, toc, link.path):
-                toc.findTocItem(link.docUrl.getDirName(), link.docUrl.getFileName());
+        TocItem tocItem = findTocItemByLink(link);
+
         if (tocItem == null) {
             return Optional.of(createInvalidLinkMessage(link));
         }
@@ -167,6 +166,16 @@ class WebSiteDocStructure implements DocStructure {
         }
 
         return Optional.of(createInvalidLinkMessage(link));
+    }
+
+    private TocItem findTocItemByLink(LinkToValidate link) {
+        if (link.docUrl.isIndexUrl()) {
+            return toc.getIndex();
+        }
+
+        return link.docUrl.isAnchorOnly() ?
+                parsingConfiguration.tocItemByPath(componentsRegistry, toc, link.path):
+                toc.findTocItem(link.docUrl.getDirName(), link.docUrl.getFileName());
     }
 
     private String createInvalidLinkMessage(LinkToValidate link) {


### PR DESCRIPTION
closes #418 