### PR TITLE
znai enterprise build output monitor for zip archives with docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,12 +125,13 @@
         <ant.version>1.10.5</ant.version>
         <ant-compress.version>1.5</ant-compress.version>
         <jsoup.version>1.10.2</jsoup.version>
-        <commons-io.version>2.6</commons-io.version>
         <freemarker.version>2.3.23</freemarker.version>
+        <commons-io.version>2.6</commons-io.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-csv.version>1.4</commons-csv.version>
         <commons-compress.version>1.19</commons-compress.version>
         <commons-lang3.version>3.5</commons-lang3.version>
+        <commons-codec.version>1.4</commons-codec.version>
         <plantuml.version>1.2017.16</plantuml.version>
         <json-path.version>2.4.0</json-path.version>
         <slf4j-simple.version>1.7.25</slf4j-simple.version>
@@ -195,6 +196,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
             </dependency>
 
             <dependency>
@@ -314,12 +321,6 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson.verson}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${jackson.verson}</version>
             </dependency>
 

--- a/znai-enterprise/pom.xml
+++ b/znai-enterprise/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
         </dependency>
@@ -59,5 +64,34 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testingisdocumenting.webtau</groupId>
+            <artifactId>webtau-core-groovy</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addTestSources</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/EnterpriseComponentsRegistry.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/EnterpriseComponentsRegistry.java
@@ -23,6 +23,8 @@ import org.testingisdocumenting.znai.server.ZnaiServerConfig;
 
 public class EnterpriseComponentsRegistry implements ServerLifecycleListener {
     private static ZnaiServerConfig serverConfig;
+    private static final ZnaiEnterpriseConfig enterpriseConfig = new ZnaiEnterpriseConfig();
+
     private static DocumentationStorage documentationStorage;
 
     @Override
@@ -30,12 +32,16 @@ public class EnterpriseComponentsRegistry implements ServerLifecycleListener {
         serverConfig = config;
 
         documentationStorage = new FileBasedDocumentationStorage(
-                config.getDocStorageRoot(),
+                enterpriseConfig().getDocStorageRoot(),
                 config.getDeployRoot());
     }
 
     public static DocumentationStorage documentationStorage() {
         return documentationStorage;
+    }
+
+    public static ZnaiEnterpriseConfig enterpriseConfig() {
+        return enterpriseConfig;
     }
 
     public static ZnaiServerConfig serverConfig() {

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/ZnaiEnterpriseConfig.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/ZnaiEnterpriseConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.enterprise;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ZnaiEnterpriseConfig {
+    private final Path fsMonitorConfigPath;
+    private final Path docStorageRoot;
+
+    public ZnaiEnterpriseConfig() {
+        fsMonitorConfigPath = buildFsMonitorConfigPath();
+        docStorageRoot = buildDocStorageRoot();
+    }
+
+    public Path getFsMonitorConfigPath() {
+        return fsMonitorConfigPath;
+    }
+
+    public Path getDocStorageRoot() {
+        return docStorageRoot;
+    }
+
+    private Path buildFsMonitorConfigPath() {
+        return Paths.get(propertyOrDefault("znaiFsMonitorConfig", "monitor.config.json"));
+    }
+
+    private Path buildDocStorageRoot() {
+        String docStoragePath = propertyOrDefault("znaiDocStoragePath", "");
+        return docStoragePath.isEmpty() ? null : Paths.get(docStoragePath);
+    }
+
+    private static String propertyOrDefault(String key, String defaultValue) {
+        return System.getProperty(key, defaultValue);
+    }
+}

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/docpreparation/StorageBasedDocumentationPreparationHandler.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/docpreparation/StorageBasedDocumentationPreparationHandler.java
@@ -20,13 +20,12 @@ import org.testingisdocumenting.znai.server.docpreparation.DocumentationPreparat
 import org.testingisdocumenting.znai.server.docpreparation.DocumentationPreparationProgress;
 import org.testingisdocumenting.znai.website.DocumentationFileBasedTimestamp;
 
-import static org.testingisdocumenting.znai.enterprise.EnterpriseComponentsRegistry.documentationStorage;
-import static org.testingisdocumenting.znai.enterprise.EnterpriseComponentsRegistry.serverConfig;
+import static org.testingisdocumenting.znai.enterprise.EnterpriseComponentsRegistry.*;
 
 public class StorageBasedDocumentationPreparationHandler implements DocumentationPreparationHandler {
     @Override
     public boolean handles(String docId) {
-        return serverConfig().getDocStorageRoot() != null;
+        return enterpriseConfig().getDocStorageRoot() != null;
     }
 
     @Override

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/BuildOutputMonitor.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/BuildOutputMonitor.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.enterprise.monitoring;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.testingisdocumenting.znai.console.ConsoleOutputs;
+import org.testingisdocumenting.znai.console.ansi.Color;
+import org.testingisdocumenting.znai.fs.FsUtils;
+import org.testingisdocumenting.znai.server.ServerLifecycleListener;
+import org.testingisdocumenting.znai.server.ZnaiServerConfig;
+import org.testingisdocumenting.znai.utils.FileUtils;
+import org.testingisdocumenting.znai.utils.JsonUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.testingisdocumenting.znai.enterprise.EnterpriseComponentsRegistry.documentationStorage;
+import static org.testingisdocumenting.znai.enterprise.EnterpriseComponentsRegistry.enterpriseConfig;
+
+public class BuildOutputMonitor implements ServerLifecycleListener {
+    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+
+    private final FilesFinder filesFinder;
+    private final MonitorConfig monitorConfig;
+
+    private final Map<Path, String> checkSumByPath;
+
+    public BuildOutputMonitor() {
+        this(parseMonitoringConfig());
+    }
+
+    public BuildOutputMonitor(MonitorConfig monitorConfig) {
+        this.filesFinder = new FilesFinder(monitorConfig.getBuildRootsAndPatterns());
+        this.monitorConfig = monitorConfig;
+        this.checkSumByPath = new HashMap<>();
+    }
+
+    @Override
+    public void beforeStart(ZnaiServerConfig config) {
+        start();
+    }
+
+    public void start() {
+        executorService.scheduleAtFixedRate(this::scan, 0, monitorConfig.getIntervalMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private void scan() {
+        List<Path> found = filesFinder.find();
+        found.stream()
+                .filter(this::isChecksumDifferent)
+                .forEach(this::process);
+    }
+
+    private void process(Path zip) {
+        try {
+            unzipAndStore(zip);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void unzipAndStore(Path zip) {
+        Path tempDir = FsUtils.createTempDir("znai-unzipped-doc");
+
+        FsUtils.unzip(zip, tempDir);
+
+        Path docsDir = listFiles(tempDir)
+                .filter(Files::isDirectory)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("no directory found inside zip"));
+
+        String docId = docsDir.getFileName().toString();
+
+        ConsoleOutputs.out("detected ", Color.WHITE, docId, Color.BLUE, " at ", Color.PURPLE, zip);
+        documentationStorage().store(docId, "", docsDir);
+
+        FsUtils.deleteDirectory(tempDir);
+    }
+
+    private boolean isChecksumDifferent(Path path) {
+        String previousCheckSum = checkSumByPath.get(path);
+        String newCheckSum = checkSum(path);
+
+        checkSumByPath.put(path, newCheckSum);
+
+        if (previousCheckSum == null) {
+            return true;
+        }
+
+        return !previousCheckSum.equals(newCheckSum);
+    }
+
+    private String checkSum(Path path) {
+        try {
+            return DigestUtils.md5Hex(Files.newInputStream(path));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Stream<Path> listFiles(Path tempDir) {
+        try {
+            return Files.list(tempDir);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static MonitorConfig parseMonitoringConfig() {
+        Path fsMonitorConfigPath = enterpriseConfig().getFsMonitorConfigPath();
+        if (!Files.exists(fsMonitorConfigPath)) {
+            return new MonitorConfig(Collections.emptyMap());
+        }
+
+        Map<String, ?> config = JsonUtils.deserializeAsMap(FileUtils.fileTextContent(
+                fsMonitorConfigPath));
+
+        return new MonitorConfig((Map<String, Object>) config);
+    }
+}

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/BuildOutputMonitor.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/BuildOutputMonitor.java
@@ -121,9 +121,9 @@ public class BuildOutputMonitor implements ServerLifecycleListener {
         }
     }
 
-    private static Stream<Path> listFiles(Path tempDir) {
+    private static Stream<Path> listFiles(Path dir) {
         try {
-            return Files.list(tempDir);
+            return Files.list(dir);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/BuildRootAndWildCardPatterns.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/BuildRootAndWildCardPatterns.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.enterprise.monitoring;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public class BuildRootAndWildCardPatterns {
+    private final Path buildRoot;
+    private final List<String> wildCardPatterns;
+
+    public BuildRootAndWildCardPatterns(Path buildRoot, List<String> wildCardPatterns) {
+        this.buildRoot = buildRoot.toAbsolutePath();
+        this.wildCardPatterns = wildCardPatterns;
+    }
+
+    public Path getBuildRoot() {
+        return buildRoot;
+    }
+
+    public List<String> getWildCardPatterns() {
+        return wildCardPatterns;
+    }
+}

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/FilesFinder.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/FilesFinder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.enterprise.monitoring;
+
+import org.apache.tools.ant.DirectoryScanner;
+import org.testingisdocumenting.znai.console.ConsoleOutputs;
+import org.testingisdocumenting.znai.console.ansi.Color;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FilesFinder {
+    private final List<BuildRootAndWildCardPatterns> buildRootAndWildCardPatterns;
+
+    public FilesFinder(List<BuildRootAndWildCardPatterns> buildRootAndWildCardPatterns) {
+        this.buildRootAndWildCardPatterns = buildRootAndWildCardPatterns;
+    }
+
+    public List<Path> find() {
+        return buildRootAndWildCardPatterns.stream()
+                .flatMap(rootAndPatterns -> find(rootAndPatterns).stream())
+                .collect(Collectors.toList());
+    }
+
+    private List<Path> find(BuildRootAndWildCardPatterns buildRootAndWildCardPatterns) {
+        ConsoleOutputs.out("scanning ", Color.PURPLE, buildRootAndWildCardPatterns.getBuildRoot(),
+                Color.WHITE, " patterns\n  ", String.join("\n  ", buildRootAndWildCardPatterns.getWildCardPatterns()));
+
+        DirectoryScanner scanner = new DirectoryScanner();
+        scanner.setBasedir(buildRootAndWildCardPatterns.getBuildRoot().toFile());
+        scanner.setIncludes(buildRootAndWildCardPatterns.getWildCardPatterns().toArray(new String[0]));
+        scanner.scan();
+
+        return Arrays.stream(scanner.getIncludedFiles())
+                .map(filePath -> buildRootAndWildCardPatterns.getBuildRoot().resolve(filePath))
+                .collect(Collectors.toList());
+    }
+}

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/MonitorConfig.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/monitoring/MonitorConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.enterprise.monitoring;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class MonitorConfig {
+    private final int intervalMillis;
+    private final List<BuildRootAndWildCardPatterns> buildRootsAndPatterns;
+
+    public MonitorConfig(Map<String, Object> config) {
+        this.intervalMillis = extractInterval(config, (int) TimeUnit.MINUTES.toMillis(1));
+        this.buildRootsAndPatterns = extractRootAndPatterns(config);
+    }
+
+    public long getIntervalMillis() {
+        return intervalMillis;
+    }
+
+    public List<BuildRootAndWildCardPatterns> getBuildRootsAndPatterns() {
+        return buildRootsAndPatterns;
+    }
+
+    private static Path extractRootDir(Map<String, Object> config) {
+        return Paths.get(config.getOrDefault("rootDir", "").toString());
+    }
+
+    private static int extractInterval(Map<String, Object> config, int defaultValue) {
+        return (int) config.getOrDefault("intervalMillis", defaultValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<BuildRootAndWildCardPatterns> extractRootAndPatterns(Map<String, Object> config) {
+        List<Map<String, Object>> paths =
+                (List<Map<String, Object>>) config.getOrDefault("paths", Collections.emptyList());
+
+        return paths.stream()
+                .map(rootAndPatterns -> new BuildRootAndWildCardPatterns(
+                        extractRootDir(rootAndPatterns),
+                        extractWildCardPatterns(rootAndPatterns)))
+                .collect(Collectors.toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> extractWildCardPatterns(Map<String, Object> config) {
+        return (List<String>) config.getOrDefault("wildCardPatterns", Collections.emptyList());
+    }
+}

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/storage/FileBasedDocumentationStorage.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/storage/FileBasedDocumentationStorage.java
@@ -16,7 +16,8 @@
 
 package org.testingisdocumenting.znai.enterprise.storage;
 
-import org.apache.commons.io.FileUtils;
+import org.testingisdocumenting.znai.console.ConsoleOutputs;
+import org.testingisdocumenting.znai.console.ansi.Color;
 import org.testingisdocumenting.znai.website.DocumentationFileBasedTimestamp;
 import org.testingisdocumenting.znai.server.docpreparation.DocumentationPreparationProgress;
 
@@ -24,6 +25,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+
+import static org.testingisdocumenting.znai.fs.FsUtils.*;
 
 public class FileBasedDocumentationStorage implements DocumentationStorage {
     private final Path storageRoot;
@@ -36,9 +39,11 @@ public class FileBasedDocumentationStorage implements DocumentationStorage {
 
     @Override
     public void store(String docId, String version, Path generatedDocumentation) {
-        Path dest = docsRoot.resolve(docId).resolve(version);
+        Path dest = storageRoot.resolve(docId).resolve(version);
         deleteDirectory(dest);
         copyDirectory(generatedDocumentation, dest);
+
+        ConsoleOutputs.out("stored ", Color.WHITE, docId, Color.BLUE, " as ", Color.PURPLE, dest);
     }
 
     @Override
@@ -75,29 +80,5 @@ public class FileBasedDocumentationStorage implements DocumentationStorage {
     @Override
     public long lastUpdateTime(String docId, String version) {
         return DocumentationFileBasedTimestamp.read(storageRoot.resolve(docId).resolve(version));
-    }
-
-    private void deleteDirectory(Path dest) {
-        try {
-            FileUtils.deleteDirectory(dest.toFile());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void moveDirectory(Path src, Path dest) {
-        try {
-            FileUtils.moveDirectory(src.toFile(), dest.toFile());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void copyDirectory(Path src, Path dest) {
-        try {
-            FileUtils.copyDirectory(src.toFile(), dest.toFile());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/upload/UnzipAndStoreOnUploadFinishedServerHandler.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/enterprise/upload/UnzipAndStoreOnUploadFinishedServerHandler.java
@@ -18,6 +18,7 @@ package org.testingisdocumenting.znai.enterprise.upload;
 
 import org.testingisdocumenting.znai.console.ConsoleOutputs;
 import org.testingisdocumenting.znai.console.ansi.Color;
+import org.testingisdocumenting.znai.fs.FsUtils;
 import org.testingisdocumenting.znai.server.ZnaiServerConfig;
 
 import java.nio.file.Path;
@@ -32,8 +33,7 @@ public class UnzipAndStoreOnUploadFinishedServerHandler implements OnUploadFinis
         ConsoleOutputs.out(Color.BLUE, "unzipping docs: ", Color.PURPLE, uploadedPath, Color.BLACK, " to ",
                 Color.PURPLE, unzipDest);
 
-        UnzipTask unzipTask = new UnzipTask(uploadedPath, unzipDest);
-        unzipTask.execute();
+        FsUtils.unzip(uploadedPath, unzipDest);
         ConsoleOutputs.out(Color.BLUE, "unzipped docs: ", Color.PURPLE, unzipDest);
 
         documentationStorage().store(docId, "", unzipDest);

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/fs/FsUtils.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/fs/FsUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.fs;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class FsUtils {
+    private FsUtils() {
+    }
+
+    public static void unzip(Path zip, Path dest) {
+        UnzipTask unzipTask = new UnzipTask(zip, dest);
+        unzipTask.execute();
+    }
+
+    public static void deleteDirectory(Path dest) {
+        try {
+            FileUtils.deleteDirectory(dest.toFile());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void moveDirectory(Path src, Path dest) {
+        try {
+            FileUtils.moveDirectory(src.toFile(), dest.toFile());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void copyDirectory(Path src, Path dest) {
+        try {
+            FileUtils.copyDirectory(src.toFile(), dest.toFile());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Path createTempDir(String prefix) {
+        try {
+            return Files.createTempDirectory(prefix);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/znai-enterprise/src/main/java/org/testingisdocumenting/znai/fs/UnzipTask.java
+++ b/znai-enterprise/src/main/java/org/testingisdocumenting/znai/fs/UnzipTask.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.testingisdocumenting.znai.enterprise.upload;
+package org.testingisdocumenting.znai.fs;
 
 import org.apache.ant.compress.taskdefs.Unzip;
 import org.apache.tools.ant.Project;

--- a/znai-enterprise/src/main/resources/META-INF/services/org.testingisdocumenting.znai.server.ServerLifecycleListener
+++ b/znai-enterprise/src/main/resources/META-INF/services/org.testingisdocumenting.znai.server.ServerLifecycleListener
@@ -15,3 +15,4 @@
 #
 
 org.testingisdocumenting.znai.enterprise.EnterpriseComponentsRegistry
+org.testingisdocumenting.znai.enterprise.monitoring.BuildOutputMonitor

--- a/znai-enterprise/src/test/groovy/org/testingisdocumenting/znai/enterprise/monitoring/FilesFinderTest.groovy
+++ b/znai-enterprise/src/test/groovy/org/testingisdocumenting/znai/enterprise/monitoring/FilesFinderTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.enterprise.monitoring
+
+import org.junit.Test
+
+import java.nio.file.Paths
+
+class FilesFinderTest {
+    @Test
+    void "should find files by pattern"() {
+        def found = new FilesFinder(
+                [new BuildRootAndWildCardPatterns(
+                        Paths.get(""),
+                        ["src/test/groovy/**/*FinderTest.groovy"])]).find()
+
+        found.size().should == 1
+        found[0].fileName.toString().should == 'FilesFinderTest.groovy'
+        found[0].parent.fileName.toString().should == 'monitoring'
+    }
+}

--- a/znai-enterprise/src/test/groovy/org/testingisdocumenting/znai/enterprise/monitoring/MonitorConfigTest.groovy
+++ b/znai-enterprise/src/test/groovy/org/testingisdocumenting/znai/enterprise/monitoring/MonitorConfigTest.groovy
@@ -20,11 +20,18 @@ import org.junit.Test
 
 class MonitorConfigTest {
     @Test
-    void "should be able to pass list of wildcards"() {
+    void "should maintain a list of roots and associated wild card patterns"() {
         def config = new MonitorConfig([
-                fileMatchPatterns: ["znai-*.zip", "doxygen.zip"]
-        ])
+                "intervalMillis": 20000,
+                "paths": [[
+                     "rootDir": "/home/fake-build-dir",
+                     "wildCardPatterns": ["*/*.zip", "inner/*/*.zip"]]]])
 
-        config.wildCardPatterns.should == ["znai.zip", "doxygen.zip"]
+        config.intervalMillis.should == 20000
+
+        println config.buildRootsAndPatterns
+        config.buildRootsAndPatterns.size().should == 1
+        config.buildRootsAndPatterns[0].buildRoot.toString().should == "/home/fake-build-dir"
+        config.buildRootsAndPatterns[0].wildCardPatterns.should == ["*/*.zip", "inner/*/*.zip"]
     }
 }

--- a/znai-enterprise/src/test/groovy/org/testingisdocumenting/znai/enterprise/monitoring/MonitorConfigTest.groovy
+++ b/znai-enterprise/src/test/groovy/org/testingisdocumenting/znai/enterprise/monitoring/MonitorConfigTest.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.enterprise.monitoring
+
+import org.junit.Test
+
+class MonitorConfigTest {
+    @Test
+    void "should be able to pass list of wildcards"() {
+        def config = new MonitorConfig([
+                fileMatchPatterns: ["znai-*.zip", "doxygen.zip"]
+        ])
+
+        config.wildCardPatterns.should == ["znai.zip", "doxygen.zip"]
+    }
+}

--- a/znai-enterprise/src/test/resources/monitor.config.json
+++ b/znai-enterprise/src/test/resources/monitor.config.json
@@ -1,0 +1,11 @@
+{
+  "intervalMillis": 20000,
+  "paths": [
+    {
+      "rootDir": "/Users/mykolagolubyev/work/fake-build-dir",
+      "wildCardPatterns": [
+        "*/*.zip"
+      ]
+    }
+  ]
+}

--- a/znai-server/src/main/java/org/testingisdocumenting/znai/server/ZnaiServerConfig.java
+++ b/znai-server/src/main/java/org/testingisdocumenting/znai/server/ZnaiServerConfig.java
@@ -17,21 +17,17 @@
 package org.testingisdocumenting.znai.server;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class ZnaiServerConfig {
     private final String serverTitle;
     private final String serverType;
 
     private final Path deployRoot;
-    private final Path docStorageRoot;
 
     public ZnaiServerConfig(Path deployRoot) {
         this.serverTitle = propertyOrDefault("znaiTitle", "Company");
         this.serverType = propertyOrDefault("znaiType", "Guides");
         this.deployRoot = deployRoot;
-
-        this.docStorageRoot = buildDocStoragePath();
     }
 
     public String getServerTitle() {
@@ -44,15 +40,6 @@ public class ZnaiServerConfig {
 
     public Path getDeployRoot() {
         return deployRoot;
-    }
-
-    public Path getDocStorageRoot() {
-        return docStorageRoot;
-    }
-
-    private Path buildDocStoragePath() {
-        String docStoragePath = propertyOrDefault("docStoragePath", "");
-        return docStoragePath.isEmpty() ? null : Paths.get(docStoragePath);
     }
 
     private static String propertyOrDefault(String key, String defaultValue) {


### PR DESCRIPTION
periodically checks specified directories and wild card patterns.
Once a new documentation zip is detected, unpacks it to temporary location to extract doc id (directory name) and store using active storage implementation.

Use case is to monitor bazel outputs assuming the output produces a zip archive on a filesystem that is visible to a znai enterprise server. 