### PR TITLE
add include-file start,end,include,exclude docs. add exclude by regexp(s)

### DIFF
--- a/znai-core/src/test/groovy/org/testingisdocumenting/znai/extensions/file/FileIncludePluginTest.groovy
+++ b/znai-core/src/test/groovy/org/testingisdocumenting/znai/extensions/file/FileIncludePluginTest.groovy
@@ -42,7 +42,7 @@ class FileIncludePluginTest {
 
     @Test
     void "should extract file snippet based on start and stop end lines excluding them"() {
-        def text = resultingSnippet("file.txt", "{startLine: 'number', endLine: 'stop', exclude: true}")
+        def text = resultingSnippet("file.txt", "{startLine: 'number', endLine: 'stop', excludeStartEnd: true}")
 
         text.should == ""
     }
@@ -71,11 +71,11 @@ class FileIncludePluginTest {
 
     @Test
     void "should automatically strip extra indentation"() {
-        def text = resultingSnippet("script.groovy", "{startLine: 'class', endLine: '}', exclude: true}")
+        def text = resultingSnippet("script.groovy", "{startLine: 'class', endLine: '}', excludeStartEnd: true}")
 
         text.should ==
                 "def a\n" +
-                "def b"
+                "int b"
     }
 
     @Test
@@ -87,6 +87,28 @@ class FileIncludePluginTest {
         allImports.should ==
                 "import e.d.g.AnotherName\n" +
                 "import a.b.c.ClassName"
+    }
+
+    @Test
+    void "should only include lines matching regexps list"() {
+        def result = resultingSnippet("script.groovy", "{includeRegexp: ['int', 'def']}")
+        result.should == "def a\n" +
+                "int b"
+    }
+
+    @Test
+    void "should exclude lines matching regexp"() {
+        def withoutMarkers = resultingSnippet("sample-with-marker.py", "{excludeRegexp: '# exa..le'}")
+        withoutMarkers.should == "print(\"hello\")"
+    }
+
+    @Test
+    void "should exclude lines matching regexps list"() {
+        def withoutMarkers = resultingSnippet("sample-with-multi-marker.py",
+                '{excludeRegexp: ["# example", "# .rocedur."]}')
+        withoutMarkers.should == "print(\"hello\")\n" +
+                "\n" +
+                "print(\"hello world\")"
     }
 
     @Test
@@ -110,14 +132,14 @@ class FileIncludePluginTest {
                 "\n" +
                 "class HelloWorld {\n" +
                 "    def a\n" +
-                "    def b\n" +
+                "    int b\n" +
                 "}")
     }
 
     @Test
     void "should highlight lines from a highlight text file"() {
         def props = resultingProps("script.groovy", "{highlightPath: 'highlight.txt'}")
-        props.highlight.should == ['def a', 'def b']
+        props.highlight.should == ['def a', 'int b']
     }
 
     @Test

--- a/znai-core/src/test/resources/highlight.txt
+++ b/znai-core/src/test/resources/highlight.txt
@@ -1,2 +1,2 @@
 def a
-def b
+int b

--- a/znai-core/src/test/resources/sample-with-marker.py
+++ b/znai-core/src/test/resources/sample-with-marker.py
@@ -1,0 +1,3 @@
+# example: how to print
+print("hello")
+# example-end

--- a/znai-core/src/test/resources/sample-with-multi-marker.py
+++ b/znai-core/src/test/resources/sample-with-multi-marker.py
@@ -1,0 +1,7 @@
+# example: how to print
+print("hello")
+# example-end
+
+# procedure: how to print
+print("hello world")
+# procedure-end

--- a/znai-core/src/test/resources/script.groovy
+++ b/znai-core/src/test/resources/script.groovy
@@ -3,5 +3,5 @@ import a.b.c.ClassName
 
 class HelloWorld {
     def a
-    def b
+    int b
 }

--- a/znai-docs/znai/snippets/external-code-snippets.md
+++ b/znai-docs/znai/snippets/external-code-snippets.md
@@ -70,6 +70,47 @@ Use the `highlightPath` option to highlight lines specified in a separate file.
 
 :include-file: lines-to-highlight.txt {title: "lines-to-highlight.txt"}
 
+# Limit
+
+Use `startLine`, `endLine` to limit the included content.
+
+If you have a file with embedded examples, you can use limit function to extract small samples by using marker lines.
+
+:include-file: python-examples.py {title: "file with examples"} 
+
+    :include-file: python-examples.py {startLine: "example: book trade", endLine: "example-end"}
+     
+:include-file: python-examples.py {title: "extracted example", startLine: "example: book trade", endLine: "example-end"}
+
+Note: Lines match doesn't have to be exact, `contains` is used.
+ 
+By default `startLine` and `endLine` are included in the rendered result. Use `excludeStartEnd: true` to remove markers.   
+
+    :include-file: python-examples.py { 
+        startLine: "example: book trade",
+        endLine: "example-end",
+        excludeStartEnd: true }
+
+:include-file: python-examples.py {
+    title: "extracted example", 
+    startLine: "example: book trade",
+    endLine: "example-end",
+    excludeStartEnd: true }
+    
+Use `includeRegexp` to include only lines matching regexp(s).
+
+    :include-file: python-examples.py {includeRegexp: "import"}
+    :include-file: python-examples.py {includeRegexp: ["import"]}
+    
+:include-file: python-examples.py { includeRegexp: ["import"], title: "include by regexp" }
+
+Use `excludeRegexp` to exclude lines matching regexp(s).
+
+    :include-file: python-examples.py {excludeRegexp: "# example"}
+    :include-file: python-examples.py {excludeRegexp: ["# example"]}
+    
+:include-file: python-examples.py { excludeRegexp: ["# example"], title: "exclude by regexp" }
+
 # Callout Comments
 
 If you already have comments inside your code it would be non effecient to repeat them inside documentation. 

--- a/znai-docs/znai/snippets/python-examples.py
+++ b/znai-docs/znai/snippets/python-examples.py
@@ -1,0 +1,13 @@
+import market
+
+def main():
+    # example: book trade
+    id = market.book_trade('symbol', market.CURRENT_PRICE, 100)
+    # example-end
+
+    # example: cancel trade
+    market.cancel_trade('id')
+    # example-end
+
+if __name__  == "__main__":
+    main()


### PR DESCRIPTION
@jyeakel please note new examples.
also `exclude` param to `include-file` was replaced with `excludeStartEnd`. They never were documented, so I hope no one is going to be affected.