### PR TITLE
print znai version and timestamp on start

### DIFF
--- a/znai-cli/src/main/java/org/testingisdocumenting/znai/cli/ZnaiCliConfig.java
+++ b/znai-cli/src/main/java/org/testingisdocumenting/znai/cli/ZnaiCliConfig.java
@@ -23,6 +23,7 @@ import org.testingisdocumenting.znai.console.ConsoleOutputs;
 import org.testingisdocumenting.znai.console.ansi.Color;
 import org.testingisdocumenting.znai.parser.MarkupTypes;
 import org.apache.commons.cli.*;
+import org.testingisdocumenting.znai.version.ZnaiVersion;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -186,6 +187,8 @@ public class ZnaiCliConfig {
     }
 
     public void print() {
+        printVersion();
+
         if (!isScaffoldMode() && !isServeMode()) {
             print("source root", sourceRoot);
         }
@@ -216,6 +219,7 @@ public class ZnaiCliConfig {
 
         if (commandLine.hasOption(HELP_KEY) || args.length < 1) {
             HelpFormatter helpFormatter = new HelpFormatter();
+            printVersion();
             helpFormatter.printHelp("znai", options);
             System.exit(1);
         }
@@ -249,6 +253,11 @@ public class ZnaiCliConfig {
         modifiedTimeStrategy = determineModifiedTimeStrategy(commandLine);
 
         validateMode(commandLine);
+    }
+
+    private void printVersion() {
+        ConsoleOutputs.out(Color.YELLOW, "znai version: ", Color.CYAN, ZnaiVersion.getVersion(),
+                Color.GREEN, " (", ZnaiVersion.getTimeStamp(), ")");
     }
 
     private Mode determineMode(CommandLine commandLine) {

--- a/znai-core/pom.xml
+++ b/znai-core/pom.xml
@@ -26,6 +26,11 @@
 
     <artifactId>znai-core</artifactId>
 
+    <properties>
+        <build.timestamp>${maven.build.timestamp}</build.timestamp>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.atlassian.commonmark</groupId>
@@ -103,6 +108,13 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>

--- a/znai-core/src/main/java/org/testingisdocumenting/znai/version/ZnaiVersion.java
+++ b/znai-core/src/main/java/org/testingisdocumenting/znai/version/ZnaiVersion.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testingisdocumenting.znai.version;
+
+import org.testingisdocumenting.znai.utils.ResourceUtils;
+
+public class ZnaiVersion {
+    private static final String version;
+    private static final String timeStamp;
+
+    static {
+        String[] versionTimeStamp = ResourceUtils.textContent("znai-version.txt").trim().split(" ");
+        version = versionTimeStamp[0];
+        timeStamp = versionTimeStamp[1];
+    }
+
+    private ZnaiVersion() {
+    }
+
+    public static String getVersion() {
+        return version;
+    }
+
+    public static String getTimeStamp() {
+        return timeStamp;
+    }
+}

--- a/znai-core/src/main/resources/znai-version.txt
+++ b/znai-core/src/main/resources/znai-version.txt
@@ -1,0 +1,1 @@
+${project.version} ${build.timestamp}


### PR DESCRIPTION
@byc1234 it may affect the output of your internal build. Since you are building from head most of the time `version` will contain `SNAPSHOT` suffix. 
A quick fix would be to use maven version plugin to set a version before build. 
Alternatively we can add a system property flag to remove SNAPSHOT or force a version. 