### PR TITLE
presentation: initial presenter mode

### DIFF
--- a/znai-reactjs/src/doc-elements/presentation/Presentation.css
+++ b/znai-reactjs/src/doc-elements/presentation/Presentation.css
@@ -64,7 +64,7 @@
     color: var(--znai-presentation-title-divider);
 }
 
-.presentation .header .controls {
+.znai-presentation-controls {
     display: flex;
     flex: 0 0 80px;
     align-items: center;
@@ -74,15 +74,15 @@
     color: var(--znai-presentation-slide-info-color);
 }
 
-.presentation .header .controls .close {
+.znai-presentation-controls .close {
     color: var(--znai-presentation-slide-info-color);
     margin: 20px;
     cursor: pointer;
 }
 
-.znai-presentation-slides-area {
-    flex: 1;
-    overflow-y: hidden;
+.znai-presenter-mode-toggle {
+    cursor: pointer;
+    margin-right: 16px;
 }
 
 .presentation .content-block {

--- a/znai-reactjs/src/doc-elements/presentation/PresenterMode.css
+++ b/znai-reactjs/src/doc-elements/presentation/PresenterMode.css
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.znai-presenter-mode {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    width: 100%;
+    height: 100%;
+}
+
+.znai-presenter-current-next {
+    display: grid;
+    grid-template-columns: 3fr 2fr;
+    height: 100%;
+}
+
+.znai-presenter-slide {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+
+    border-right: 1px solid var(--znai-presentation-border-color);
+}
+
+.znai-presenter-slide-title {
+    background-color: var(--znai-presentation-slide-info-background-color);
+    border-bottom: 1px solid var(--znai-presentation-border-color);
+    padding-top: 4px;
+    padding-bottom: 4px;
+    text-align: center;
+}

--- a/znai-reactjs/src/doc-elements/presentation/PresenterMode.tsx
+++ b/znai-reactjs/src/doc-elements/presentation/PresenterMode.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import PresentationRegistry from './PresentationRegistry';
+
+import { SlidePanel } from './SlidePanel';
+
+import './PresenterMode.css';
+
+interface Props {
+  presentationRegistry: PresentationRegistry;
+  slideIdx: number;
+}
+
+export function PresenterMode({presentationRegistry, slideIdx}: Props) {
+  return (
+    <div className="znai-presenter-mode">
+      <div className="znai-presenter-current-next">
+        <SlideContent label="next" presentationRegistry={presentationRegistry} slideIdx={slideIdx + 1}/>
+        <SlideContent label="after next" presentationRegistry={presentationRegistry} slideIdx={slideIdx + 2}/>
+      </div>
+    </div>
+  );
+}
+
+interface ContentProps extends Props {
+  label: string;
+}
+
+function SlideContent({label, presentationRegistry, slideIdx}: ContentProps) {
+  return (
+    <div className="znai-presenter-slide">
+      <div className="znai-presenter-slide-title">{label}</div>
+      <SlidePanel presentationRegistry={presentationRegistry} currentSlideIdx={slideIdx}/>
+    </div>
+  )
+}

--- a/znai-reactjs/src/doc-elements/presentation/SlidePanel.css
+++ b/znai-reactjs/src/doc-elements/presentation/SlidePanel.css
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.znai-presentation-slide-panel {
+    height: 100%;
+    overflow-y: hidden;
+}

--- a/znai-reactjs/src/doc-elements/presentation/SlidePanel.tsx
+++ b/znai-reactjs/src/doc-elements/presentation/SlidePanel.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useLayoutEffect, useRef, useState } from 'react';
+
+import { SlidesLayout } from './SlidesLayout';
+
+import PresentationRegistry from './PresentationRegistry';
+
+import { PresentationDimension } from './PresentationDimensions';
+
+import './SlidePanel.css';
+
+interface Props {
+  presentationRegistry: PresentationRegistry;
+  currentSlideIdx: number;
+}
+
+const maxScaleRatio = 3;
+
+export function SlidePanel({presentationRegistry, currentSlideIdx}: Props) {
+  const areaNode = useRef<HTMLDivElement>(null);
+  const [slideArea, setSlideArea] = useState<PresentationDimension | undefined>()
+
+  useLayoutEffect(() => {
+    if (areaNode.current) {
+      setSlideArea(calcSlideArea(areaNode.current));
+    }
+  }, [currentSlideIdx])
+
+  return (
+    <div ref={areaNode} className="znai-presentation-slide-panel">
+      {slideArea && (<SlidesLayout presentationRegistry={presentationRegistry}
+                                          currentSlideIdx={currentSlideIdx}
+                                          maxScaleRatio={maxScaleRatio}
+                                          presentationArea={slideArea}/>)
+      }
+    </div>
+  );
+}
+
+function calcSlideArea(node: HTMLElement) {
+  if (!node) {
+    return undefined
+  }
+
+  return {
+    width: node.offsetWidth,
+    height: node.offsetHeight
+  }
+}
+

--- a/znai-reactjs/src/doc-elements/presentation/presentationBroadcastChannel.ts
+++ b/znai-reactjs/src/doc-elements/presentation/presentationBroadcastChannel.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 znai maintainers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let channel: BroadcastChannel | undefined;
+
+function subscribe(onMessage: (message: any) => void) {
+  createChannelIfRequired();
+  channel!.onmessage = onMessage;
+}
+
+function unsubscribe() {
+  if (!channel) {
+    return;
+  }
+
+  channel.close();
+  channel = undefined;
+}
+
+function sendMessage(message: any) {
+  createChannelIfRequired();
+  console.log('posting message', message);
+  channel!.postMessage(message);
+}
+
+function createChannelIfRequired() {
+  if (!channel) {
+    channel = new BroadcastChannel('znai_presentation');
+  }
+}
+
+export const presentationBroadcast = {
+  subscribe,
+  unsubscribe,
+  sendMessage
+}


### PR DESCRIPTION
Presentation mode has now icon to switch to presenter mode.
You can open the same presentation on two different browsers and use presenter mode to see what's next two slides are.

<img width="1366" alt="Screen Shot 2020-09-16 at 10 43 37 PM" src="https://user-images.githubusercontent.com/11657860/93413925-4cfd9680-f86e-11ea-82b2-639c0bdb255d.png">

Timer, notes extracted from documentation page and other features will be in a separate PR