### PR TITLE
python: parser improvements 

### DIFF
--- a/znai-docs/znai/snippets/python.md
+++ b/znai-docs/znai/snippets/python.md
@@ -1,5 +1,7 @@
 # Function Content
 
+Note: Function Content support requires running znai in an environemnt with Python 3.8 or later.
+
 Use `include-python` plugin to extract a function content.
 
 :include-file: python/example.py {title: "example.py"}

--- a/znai-python/src/main/java/org/testingisdocumenting/znai/python/PythonBasedPythonParser.java
+++ b/znai-python/src/main/java/org/testingisdocumenting/znai/python/PythonBasedPythonParser.java
@@ -56,8 +56,9 @@ public class PythonBasedPythonParser {
 
         boolean success = (boolean) parserResponse.get("success");
         if (!success) {
-            System.out.println(parserResponse.get("error"));
-            throw new RuntimeException("Error from python parser");
+            String error = (String) parserResponse.get("error");
+            System.out.println(error);
+            throw new RuntimeException("Error from python parser: " + error);
         }
 
         List<String> warnings = (List<String>) parserResponse.get("warnings");

--- a/znai-python/src/main/java/org/testingisdocumenting/znai/python/PythonBasedPythonParser.java
+++ b/znai-python/src/main/java/org/testingisdocumenting/znai/python/PythonBasedPythonParser.java
@@ -47,11 +47,26 @@ public class PythonBasedPythonParser {
         write(path);
         String json = read();
 
+        Map<String, Object> parserResponse;
         try {
-            return new PythonCode((List<Map<String, Object>>) JsonUtils.deserializeAsList(json));
+            parserResponse = (Map<String, Object>) JsonUtils.deserializeAsMap(json);
         } catch (Exception e) {
             throw new RuntimeException("can't parse python parser output: " + json, e);
         }
+
+        boolean success = (boolean) parserResponse.get("success");
+        if (!success) {
+            System.out.println(parserResponse.get("error"));
+            throw new RuntimeException("Error from python parser");
+        }
+
+        List<String> warnings = (List<String>) parserResponse.get("warnings");
+        if (warnings != null && warnings.size() > 0) {
+            System.out.println("Warnings from python parsing:");
+            warnings.forEach(warning -> System.out.println("\t" + warning));
+        }
+
+        return new PythonCode((List<Map<String, Object>>) parserResponse.get("result"));
     }
 
     private void write(Path path) {

--- a/znai-python/src/main/resources/python_parser.py
+++ b/znai-python/src/main/resources/python_parser.py
@@ -42,11 +42,17 @@ def function_to_dict(func_node):
 
 
 def extract_content(node):
+    if not hasattr(node, "end_lineno"):
+        return None
+
     global content_lines
     return "\n".join(content_lines[(node.lineno - 1):node.end_lineno])
 
 
 def extract_body_only(node):
+    if not hasattr(node, "end_lineno"):
+        return None
+
     # skip py doc if present
     start_idx = 1 if is_py_doc(node.body[0]) else 0
     end_idx = len(node.body) - 1

--- a/znai-python/src/main/resources/python_parser.py
+++ b/znai-python/src/main/resources/python_parser.py
@@ -15,42 +15,51 @@
 import ast
 import json
 import sys
+import traceback
 
 content_lines = []
+warnings = set([])
+
 
 def read_and_parse(file_name):
     global content_lines
     with open(file_name) as file:
         content = file.read()
         content_lines = content.splitlines()
+        warnings.clear()
 
     return ast.parse(content)
 
 
 def node_no_dict(node_type, name_to_use, node):
-    return {
-        "type": node_type,
-        "name": name_to_use,
-        "content": extract_content(node),
-        "body_only": extract_body_only(node),
-        "doc_string": ast.get_docstring(node)
-    }
+    try:
+        return {
+            "type": node_type,
+            "name": name_to_use,
+            "content": extract_content(node_type, name_to_use, node),
+            "body_only": extract_body_only(node_type, name_to_use, node),
+            "doc_string": ast.get_docstring(node)
+        }
+    except Exception as e:
+        raise Exception(f"Error processing {name_to_use} {node_type}") from e
 
 
 def function_to_dict(func_node):
     return node_no_dict("function", func_node.name, func_node)
 
 
-def extract_content(node):
+def extract_content(node_type, name_to_use, node):
     if not hasattr(node, "end_lineno"):
+        warnings.add(f"Skipping content extraction for {name_to_use} {node_type}, only supported with Python 3.8+")
         return None
 
     global content_lines
     return "\n".join(content_lines[(node.lineno - 1):node.end_lineno])
 
 
-def extract_body_only(node):
+def extract_body_only(node_type, name_to_use, node):
     if not hasattr(node, "end_lineno"):
+        warnings.add(f"Skipping content extraction for {name_to_use} {node_type}, only supported with Python 3.8+")
         return None
 
     # skip py doc if present
@@ -95,8 +104,7 @@ def parse_file(file_to_parse):
         for class_dict in dicts:
             parse_result.append(class_dict)
 
-    print(json.dumps(parse_result), flush=True)
-    print_parse_completed()
+    return parse_result
 
 
 def print_parse_completed():
@@ -106,8 +114,19 @@ def print_parse_completed():
 while True:
     line = sys.stdin.readline()
 
+    parse_result = None
+    error = None
     try:
-        parse_file(line.strip())
-    except Exception as e:
-        print(e)
-        print_parse_completed()
+        parse_result = parse_file(line.strip())
+    except:
+        error = traceback.format_exc()
+
+    success = error is not None
+    result = {
+        "success": success,
+        "warnings": list(warnings),
+        "error": error,
+        "result": parse_result
+    }
+    print(json.dumps(result), flush=True)
+    print_parse_completed()

--- a/znai-python/src/main/resources/python_parser.py
+++ b/znai-python/src/main/resources/python_parser.py
@@ -121,7 +121,7 @@ while True:
     except:
         error = traceback.format_exc()
 
-    success = error is not None
+    success = error is None
     result = {
         "success": success,
         "warnings": list(warnings),


### PR DESCRIPTION
A few changes in this PR:
1. make the parsing not fail on python 3.7 (and likely earlier too). Full functionality isn’t available, only docstring but we’ll print an appropriate warning
2. improved excepting handling to include stack trace as well as the name of the class or function
3. changed the response schema too communicate errors and warnings back from the python parser script
4. added logging of warnings and error as appropriate