### PR TITLE
python: support extraction of assignments

### DIFF
--- a/znai-docs/znai/release-notes/1.50/add-2021-06-15-python-function.md
+++ b/znai-docs/znai/release-notes/1.50/add-2021-06-15-python-function.md
@@ -1,1 +1,1 @@
-* Add [include-python](snippets/python#function-content) to include function's content
+* Add [include-python](snippets/python#content) to include function's content

--- a/znai-docs/znai/release-notes/1.52/add-2021-07-12-py-vars.md
+++ b/znai-docs/znai/release-notes/1.52/add-2021-07-12-py-vars.md
@@ -1,0 +1,1 @@
+* Add support for variables to [include-python](snippets/python#content) and revamped the entire doc section.

--- a/znai-docs/znai/release-notes/1.52/add-2021-07-12-py-vars.md
+++ b/znai-docs/znai/release-notes/1.52/add-2021-07-12-py-vars.md
@@ -1,1 +1,1 @@
-* Add support for variables to [include-python](snippets/python#content) and revamped the entire doc section.
+* Add support for variables to [include-python](snippets/python#content) and revamped the entire doc section

--- a/znai-docs/znai/release-notes/2021.md
+++ b/znai-docs/znai/release-notes/2021.md
@@ -2,6 +2,10 @@
 title: 2021 Releases
 ---
 
+# 1.52
+
+:include-markdowns: 1.52
+
 # 1.51
 
 :include-markdowns: 1.51

--- a/znai-docs/znai/snippets/python.md
+++ b/znai-docs/znai/snippets/python.md
@@ -1,8 +1,8 @@
-# Function Content
+# Content
 
 Note: Function Content support requires running znai in an environemnt with Python 3.8 or later.
 
-Use `include-python` plugin to extract a function content.
+Use `include-python` plugin to extract functuion, class or global variable content.
 
 :include-file: python/example.py {title: "example.py"}
 

--- a/znai-docs/znai/snippets/python.md
+++ b/znai-docs/znai/snippets/python.md
@@ -1,21 +1,86 @@
 # Content
 
-Note: Function Content support requires running znai in an environemnt with Python 3.8 or later.
+Note: Function Content support requires running znai in an environment with Python 3.8 or later.
 
-Use `include-python` plugin to extract functuion, class or global variable content.
+All the examples below are from the following example Python file:
 
 :include-file: python/example.py {title: "example.py"}
+
+## Full Content
+
+Use `include-python` plugin to extract function, class or global variable content.
+
+### Class
+
+To show the full class definition:
+
+    :include-python: python/example.py {entry: "Animal"}
+
+:include-python: python/example.py {entry: "Animal"}
+
+### Function
+
+To show the full contents of a function:
 
     :include-python: python/example.py {entry: "Animal.says"}
 
 :include-python: python/example.py {entry: "Animal.says"}
 
-Use `bodyOnly` to include only the content of a function without its signature. 
+This also works for global functions:
+
+    :include-python: python/example.py {entry: "my_func"}
+
+:include-python: python/example.py {entry: "my_func"}
+
+### Class
+
+To show the full contents of a class:
+
+    :include-python: python/example.py {entry: "Animal"}
+
+:include-python: python/example.py {entry: "Animal"}
+
+### Variable
+
+To show a variable's definition and assignment:
+
+    :include-python: python/example.py {entry: "my_var"}
+
+:include-python: python/example.py {entry: "my_var"}
+
+## Body Only
+
+Use `bodyOnly` to include just the "body" part of the content.  The specifics differ based on what is being included.
+
+### Function
+
+To show a function's body, without signature or doc string:
 
     :include-python: python/example.py {entry: "Animal.says", bodyOnly: true}
 
 :include-python: python/example.py {entry: "Animal.says", bodyOnly: true}
 
+This also works for global functions:
+
+    :include-python: python/example.py {entry: "my_func", bodyOnly: true}
+
+:include-python: python/example.py {entry: "my_func", bodyOnly: true}
+
+### Class
+
+To show the contents of a class without the class declaration or doc string:
+
+    :include-python: python/example.py {entry: "Animal", bodyOnly: true}
+
+:include-python: python/example.py {entry: "Animal", bodyOnly: true}
+
+### Variable
+
+To show only a variable's value:
+
+    :include-python: python/example.py {entry: "my_var", bodyOnly: true}
+
+:include-python: python/example.py {entry: "my_var", bodyOnly: true}
 
 # Doc String
 

--- a/znai-docs/znai/snippets/python/example.py
+++ b/znai-docs/znai/snippets/python/example.py
@@ -1,3 +1,5 @@
+my_var = "a variable"
+
 def my_func():
     """
     text inside my *func* doc

--- a/znai-python/src/test/groovy/org/testingisdocumenting/znai/python/PythonBasedPythonParserTest.groovy
+++ b/znai-python/src/test/groovy/org/testingisdocumenting/znai/python/PythonBasedPythonParserTest.groovy
@@ -77,5 +77,27 @@ class PythonBasedPythonParserTest {
                         "        print(\"hello\")",
                 docString: "animal top level class doc string"
         ]
+
+        parsed.findEntryByName("one_line_var").should == [
+            name: "one_line_var",
+            type: "assignment",
+            content: "one_line_var = \"one line variable assignment\"",
+            bodyOnly: "\"one line variable assignment\"",
+            docString: ""
+        ]
+
+        parsed.findEntryByName("multi_line_var").should == [
+            name: "multi_line_var",
+            type: "assignment",
+            content: "multi_line_var = {\n" +
+                "    \"line1\": \"first line\",\n" +
+                "    \"line2\": \"second line\",\n" +
+                "}",
+            bodyOnly: "{\n" +
+                "    \"line1\": \"first line\",\n" +
+                "    \"line2\": \"second line\",\n" +
+                "}",
+            docString: ""
+        ]
     }
 }

--- a/znai-python/src/test/groovy/org/testingisdocumenting/znai/python/PythonDocIncludePluginTest.groovy
+++ b/znai-python/src/test/groovy/org/testingisdocumenting/znai/python/PythonDocIncludePluginTest.groovy
@@ -48,7 +48,8 @@ class PythonDocIncludePluginTest {
         code {
             resultingProps('example.py', '{entry: "my_func_two"}')
         } should throwException("can't find entry: my_func_two in: example.py, available entries: " +
-                "a_method, func_no_docs, my_func, another_func, AClass, AClass.foo, Animal, Animal.says")
+                "a_method, func_no_docs, my_func, another_func, AClass, AClass.foo, Animal, Animal.says, " +
+                "one_line_var, multi_line_var")
     }
 
     private static Map<String, Object> resultingProps(String fileName, String value) {

--- a/znai-python/src/test/groovy/org/testingisdocumenting/znai/python/PythonIncludePluginTest.groovy
+++ b/znai-python/src/test/groovy/org/testingisdocumenting/znai/python/PythonIncludePluginTest.groovy
@@ -59,7 +59,8 @@ class PythonIncludePluginTest {
         code {
             resultingProps('example.py', '{entry: "my_func_two"}')
         } should throwException("can't find entry: my_func_two in: example.py, available entries: a_method, " +
-                "func_no_docs, my_func, another_func, AClass, AClass.foo, Animal, Animal.says")
+                "func_no_docs, my_func, another_func, AClass, AClass.foo, Animal, Animal.says, " +
+                "one_line_var, multi_line_var")
     }
 
     private static Map<String, Object> resultingProps(String fileName, String value) {

--- a/znai-python/src/test/resources/example.py
+++ b/znai-python/src/test/resources/example.py
@@ -12,6 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+one_line_var = "one line variable assignment"
+
+multi_line_var = {
+    "line1": "first line",
+    "line2": "second line",
+}
+
+
 def a_method():
     """
     This method does stuff


### PR DESCRIPTION
In this initial implementation, I'm intentionally not supporting things like this:
```python
a, b = foo()
```