### PR TITLE
images: fix svg null pointer when using include plugin

### DIFF
--- a/znai-core/src/main/java/org/testingisdocumenting/znai/parser/docelement/DocElementCreationParserHandler.java
+++ b/znai-core/src/main/java/org/testingisdocumenting/znai/parser/docelement/DocElementCreationParserHandler.java
@@ -285,13 +285,19 @@ public class DocElementCreationParserHandler implements ParserHandler {
             AuxiliaryFile auxiliaryFile = resourcesResolver.runtimeAuxiliaryFile(destination);
             BufferedImage image = resourcesResolver.imageContent(destination);
 
-            append(DocElementType.IMAGE, "title", title,
-                    "destination", docStructure.fullUrl(auxiliaryFile.getDeployRelativePath().toString()),
-                    "alt", alt,
-                    "inlined", true,
-                    "timestamp", componentsRegistry.timeService().fileModifiedTimeMillis(auxiliaryFile.getPath()),
-                    "width", image.getWidth(),
-                    "height", image.getHeight());
+            Map<String, Object> props = new HashMap<>();
+            props.put("title", title);
+            props.put("destination", docStructure.fullUrl(auxiliaryFile.getDeployRelativePath().toString()));
+            props.put("alt", alt);
+            props.put("inlined", true);
+            props.put("timestamp", componentsRegistry.timeService().fileModifiedTimeMillis(auxiliaryFile.getPath()));
+
+            if (image != null) {
+                props.put("width", image.getWidth());
+                props.put("height", image.getHeight());
+            }
+
+            append(DocElementType.IMAGE, props);
 
             auxiliaryFiles.add(auxiliaryFile);
         } else {

--- a/znai-core/src/test/groovy/org/testingisdocumenting/znai/parser/MarkdownParserTest.groovy
+++ b/znai-core/src/test/groovy/org/testingisdocumenting/znai/parser/MarkdownParserTest.groovy
@@ -313,6 +313,16 @@ world""")
                             type: 'Image']]
     }
 
+    @Test
+    void "standalone svg image"() {
+        TEST_COMPONENTS_REGISTRY.timeService().fakedFileTime = 200000
+
+        parse("![alt text](images/test.svg \"custom title\")")
+        content.should == [[title: "custom title", destination: '/test-doc/test.svg',
+                            alt: 'alt text', inlined: false,
+                            timestamp: 200000,
+                            type: 'Image']]
+    }
 
     @Test
     void "image with external ref"() {

--- a/znai-core/src/test/resources/images/test.svg
+++ b/znai-core/src/test/resources/images/test.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" >
+    <path fill="#BDDDF4" d="M13 3H7l-7 9h10z"/>
+    <path fill="#5DADEC" d="M36 12l-7-9h-6l3 9z"/>
+    <path fill="#4289C1" d="M26 12h10L18 33z"/>
+    <path fill="#8CCAF7" d="M10 12H0l18 21zm3-9l-3 9h16l-3-9z"/>
+    <path fill="#5DADEC" d="M18 33l-8-21h16z"/>
+</svg>

--- a/znai-docs/znai/release-notes/1.63/fix-2023-02-21-image-svg-null-pointer.md
+++ b/znai-docs/znai/release-notes/1.63/fix-2023-02-21-image-svg-null-pointer.md
@@ -1,0 +1,1 @@
+* Fix: [Images](visuals/images) null pointer when using with SVGs

--- a/znai-website-gen/src/main/java/org/testingisdocumenting/znai/extensions/image/ImagePluginBase.java
+++ b/znai-website-gen/src/main/java/org/testingisdocumenting/znai/extensions/image/ImagePluginBase.java
@@ -137,6 +137,10 @@ abstract class ImagePluginBase implements Plugin {
 
     private void setWidthHeight(BufferedImage bufferedImage,
                                 Map<String, Object> props) {
+        if (bufferedImage == null) {
+            return;
+        }
+
         Double pixelRatio = pixelRatio();
 
         props.put("width", bufferedImage.getWidth() / pixelRatio);


### PR DESCRIPTION
closes #1084 