### PR TITLE
Improve local build documentation and fix build issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
         <groovy.version>3.0.15</groovy.version>
         <vertx.io.version>3.9.4</vertx.io.version>
         <commonmark.version>0.23.0</commonmark.version>
@@ -433,8 +432,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.13.0</version>
                     <configuration>
+                        <release>17</release>
                         <source>17</source>
                         <target>17</target>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
         <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <httpcore.version>4.4.13</httpcore.version>
         <httpclient.version>4.5.13</httpclient.version>
+        <frontend-maven-plugin.installDirectory>.mvn</frontend-maven-plugin.installDirectory>
     </properties>
 
     <dependencyManagement>
@@ -514,7 +515,7 @@
                     </executions>
                     <configuration>
                         <nodeVersion>v12.16.3</nodeVersion>
-                        <installDirectory>.mvn</installDirectory>
+                        <installDirectory>${frontend-maven-plugin.installDirectory}</installDirectory>
                         <workingDirectory>src</workingDirectory>
                     </configuration>
                 </plugin>

--- a/znai-docs/znai/znai-development/local-build.md
+++ b/znai-docs/znai/znai-development/local-build.md
@@ -29,6 +29,20 @@ Use [brew](https://brew.sh) to install [GraphViz](http://www.graphviz.org/)
 brew install graphviz
 ```
 
+## Firefox
+
+Some automated tests in znai are using [WebTau](https://testingisdocumenting.org/webtau/getting-started/what-is-this),
+which in turn use Selenium WebDriver and firefox.
+
+A firefox executable has to be on the system path.
+
+Use [brew](https://brew.sh) to install [Firefox](https://www.mozilla.org/en-US/firefox/).
+
+```cli
+brew install firefox
+```
+
+
 # Build
 
 ```cli

--- a/znai-docs/znai/znai-development/local-build.md
+++ b/znai-docs/znai/znai-development/local-build.md
@@ -12,10 +12,10 @@ Easy way to maintain Java specific dependencies below is by using [SDKMAN](https
 
 ## Java And Maven 
 
-You need Java 8 and Maven to build Znai.
+You need Java 17 and Maven to build Znai.
 
 ```cli 
-sdk install java 8.0.342-amzn 
+sdk install java 17.0.13-amzn 
 sdk install maven
 ```
 

--- a/znai-typescript/pom.xml
+++ b/znai-typescript/pom.xml
@@ -79,6 +79,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <node.bin>${project.basedir}/${frontend-maven-plugin.installDirectory}/node/node</node.bin>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
- add documentation about how to install `firefox` so that the tests using selenium can be executed sucessfully
- document that we need Java 17 to build, not Java 8 any more
- fix an issue where node is not found in the `znai-typescript` module