### PR TITLE
bump jsonpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-codec.version>1.15</commons-codec.version>
         <plantuml.version>1.2023.12</plantuml.version>
-        <json-path.version>2.9.0</json-path.version>
+        <json-path.version>2.10.0</json-path.version>
         <slf4j.version>1.7.30</slf4j.version>
         <junit.version>4.13.1</junit.version>
         <javaparser-core.version>3.24.8</javaparser-core.version>


### PR DESCRIPTION
the reason is to indirectly bump net.minidev:json-smart to 2.6.0.

We currently have this dependency tree :

  +- com.jayway.jsonpath:json-path:jar:2.9.0:compile
  |  +- net.minidev:json-smart:jar:2.5.0:runtime

  There is a vulnerability, see https://www.mend.io/vulnerability-database/CVE-2024-57699?utm_source=JetBrains