### PR TITLE
deploy: single-slash urls for empty doc-id, trailing-slash redirects

### DIFF
--- a/znai-docs/znai/release-notes/1.92/fix-2026-08-16-empty-doc-id-root-urls.md
+++ b/znai-docs/znai/release-notes/1.92/fix-2026-08-16-empty-doc-id-root-urls.md
@@ -1,0 +1,2 @@
+* Fix: Empty `--doc-id ""` no longer generates protocol-relative `//chapter/page` links in pages, chapter redirects and `search-entries.xml`
+* Fix: Chapter and page redirects use trailing slash targets so static hosts like GitHub Pages don't serve the redirect page in a loop

--- a/znai-docs/znai/release-notes/2026.md
+++ b/znai-docs/znai/release-notes/2026.md
@@ -1,3 +1,7 @@
+# 1.92
+
+:include-markdowns: 1.92
+
 # 1.91
 
 :include-markdowns: 1.91

--- a/znai-website-gen/src/main/java/org/testingisdocumenting/znai/html/ServerSideSimplifiedRenderer.java
+++ b/znai-website-gen/src/main/java/org/testingisdocumenting/znai/html/ServerSideSimplifiedRenderer.java
@@ -44,7 +44,8 @@ public class ServerSideSimplifiedRenderer {
     }
 
     private static String renderTocLink(TocItem tocItem, String docId) {
-        String rootLink = aHref("/" + docId + "/" + tocItem.getDirName() + "/" + tocItem.getFileNameWithoutExtension() + "/",
+        String docIdPrefix = docId.isEmpty() ? "" : "/" + docId;
+        String rootLink = aHref(docIdPrefix + "/" + tocItem.getDirName() + "/" + tocItem.getFileNameWithoutExtension() + "/",
                 tocItem.getPageTitle());
 
         return article(rootLink);

--- a/znai-website-gen/src/main/java/org/testingisdocumenting/znai/website/PageRedirects.java
+++ b/znai-website-gen/src/main/java/org/testingisdocumenting/znai/website/PageRedirects.java
@@ -45,11 +45,23 @@ public class PageRedirects {
                     fromTo.newDirName + "/" + fromTo.newFileNameWithoutExtension);
         }
 
-        String redirectUrl = docStructure.fullUrl(
-                tocItem.getDirName() + "/" + tocItem.getFileNameWithoutExtension());
-        String redirectPage = ResourceUtils.textContent("template/redirect.html")
-                .replace("${newUrl}", redirectUrl);
-        deployer.deploy(fromTo.oldLink + "/index.html", redirectPage);
+        deployer.deploy(fromTo.oldLink + "/index.html", redirectPageHtml(docStructure, tocItem));
+    }
+
+    // the target ends with a slash so hosts that resolve <dir>/index.html before <dir>/index/
+    // (e.g. GitHub Pages) don't serve the redirect stub again in an infinite refresh loop
+    static String redirectPageHtml(DocStructure docStructure, TocItem tocItem) {
+        return ResourceUtils.textContent("template/redirect.html")
+                .replace("${newUrl}", redirectTargetUrl(docStructure, tocItem));
+    }
+
+    private static String redirectTargetUrl(DocStructure docStructure, TocItem tocItem) {
+        if (tocItem.isIndex()) {
+            return docStructure.fullUrl("");
+        }
+
+        String dirNamePrefix = tocItem.getDirName().isEmpty() ? "" : tocItem.getDirName() + "/";
+        return docStructure.fullUrl(dirNamePrefix + tocItem.getFileNameWithoutExtension() + "/");
     }
 
     private static List<FromTo> parse(Path csvPath) {

--- a/znai-website-gen/src/main/java/org/testingisdocumenting/znai/website/WebSite.java
+++ b/znai-website-gen/src/main/java/org/testingisdocumenting/znai/website/WebSite.java
@@ -40,7 +40,6 @@ import org.testingisdocumenting.znai.utils.FileUtils;
 import org.testingisdocumenting.znai.utils.JsonUtils;
 import org.testingisdocumenting.znai.parser.MarkupParsingConfiguration;
 import org.testingisdocumenting.znai.parser.MarkupParsingConfigurations;
-import org.testingisdocumenting.znai.utils.ResourceUtils;
 import org.testingisdocumenting.znai.website.modifiedtime.FileBasedPageModifiedTime;
 import org.testingisdocumenting.znai.website.modifiedtime.PageModifiedTimeStrategy;
 
@@ -641,11 +640,7 @@ public class WebSite implements Log {
         Set<String> dirNames = toc.getAllDirNames();
         dirNames.forEach(dirName -> {
             toc.firstPageInChapter(dirName).ifPresent((tocItem) -> {
-                String redirectUrl = docStructure.fullUrl(
-                        tocItem.getDirName() + "/" + tocItem.getFileNameWithoutExtension());
-                String redirectPage = ResourceUtils.textContent("template/redirect.html")
-                        .replace("${newUrl}", redirectUrl);
-
+                String redirectPage = PageRedirects.redirectPageHtml(docStructure, tocItem);
                 deployer.deploy(dirName + "/index.html", redirectPage);
             });
         });

--- a/znai-website-gen/src/main/java/org/testingisdocumenting/znai/website/WebSiteDocStructure.java
+++ b/znai-website-gen/src/main/java/org/testingisdocumenting/znai/website/WebSiteDocStructure.java
@@ -126,8 +126,13 @@ class WebSiteDocStructure implements DocStructure {
 
     @Override
     public String fullUrl(String relativeUrl) {
+        String docId = docMeta.getId();
+        if (docId.isEmpty()) {
+            return "/" + relativeUrl;
+        }
+
         boolean addSlash = !relativeUrl.isEmpty() && !relativeUrl.startsWith("#");
-        return  "/" + docMeta.getId() + (addSlash ? "/" : "") + relativeUrl;
+        return "/" + docId + (addSlash ? "/" : "") + relativeUrl;
     }
 
     @Override

--- a/znai-website-gen/src/test/groovy/org/testingisdocumenting/znai/html/ServerSideSimplifiedRendererTest.groovy
+++ b/znai-website-gen/src/test/groovy/org/testingisdocumenting/znai/html/ServerSideSimplifiedRendererTest.groovy
@@ -46,6 +46,24 @@ class ServerSideSimplifiedRendererTest {
     }
 
     @Test
+    void "should render TOC without double slashes when doc id is empty"() {
+        ServerSideSimplifiedRenderer.renderToc(toc, "").should ==
+                '<section id="table-of-contents" style="max-width: 640px; margin-left: auto; margin-right: auto;">\n' +
+                '<article>\n' +
+                '<a href="/chapter-a/page-one/">Page One</a>\n' +
+                '</article>\n' +
+                '\n' +
+                '<article>\n' +
+                '<a href="/chapter-a/page-two/">Page Two</a>\n' +
+                '</article>\n' +
+                '\n' +
+                '<article>\n' +
+                '<a href="/chapter-b/page-one/">Page One</a>\n' +
+                '</article>\n' +
+                '</section>\n'
+    }
+
+    @Test
     void "should render simple page for crawl indexing"() {
         def searchEntries = new PageLocalSearchEntries(
                 toc.tocItems[0], [

--- a/znai-website-gen/src/test/groovy/org/testingisdocumenting/znai/website/PageRedirectsTest.groovy
+++ b/znai-website-gen/src/test/groovy/org/testingisdocumenting/znai/website/PageRedirectsTest.groovy
@@ -1,8 +1,15 @@
 package org.testingisdocumenting.znai.website
 
+import org.testingisdocumenting.znai.core.DocMeta
+import org.testingisdocumenting.znai.html.Deployer
+import org.testingisdocumenting.znai.structure.TableOfContents
+import org.testingisdocumenting.znai.website.markups.MarkdownParsingConfiguration
 import org.junit.Test
 
+import java.nio.file.Files
+
 import static org.testingisdocumenting.webtau.WebTauCore.*
+import static org.testingisdocumenting.znai.parser.TestComponentsRegistry.TEST_COMPONENTS_REGISTRY
 
 class PageRedirectsTest {
     @Test
@@ -23,5 +30,70 @@ old-chapter/old-page-two,top-level-new-page
             PageRedirects.parse("""# optional comment
 old-chapter/old-page,new-chapter/new-page/sub-page
 """) } should throwException("invalid url format, expected [dirName/]fileName")
+    }
+
+    @Test
+    void "redirect stub target ends with trailing slash"() {
+        def docStructure = createDocStructure("product")
+        def html = PageRedirects.redirectPageHtml(docStructure,
+                docStructure.tableOfContents().findTocItem("chapter", "pageOne"))
+
+        html.should contain('url=/product/chapter/pageOne/"')
+    }
+
+    @Test
+    void "redirect stub target starts with single slash when doc id is empty"() {
+        def docStructure = createDocStructure("")
+        def html = PageRedirects.redirectPageHtml(docStructure,
+                docStructure.tableOfContents().findTocItem("chapter", "pageOne"))
+
+        html.should contain('url=/chapter/pageOne/"')
+    }
+
+    @Test
+    void "redirect stub target for top level page has no double slashes"() {
+        def docStructure = createDocStructure("product")
+        def html = PageRedirects.redirectPageHtml(docStructure,
+                docStructure.tableOfContents().findTocItem("", "top-page"))
+
+        html.should contain('url=/product/top-page/"')
+    }
+
+    @Test
+    void "redirect stub target for index page points at doc root"() {
+        def docStructure = createDocStructure("product")
+        PageRedirects.redirectPageHtml(docStructure, docStructure.tableOfContents().index)
+                .should contain('url=/product"')
+
+        def rootDocStructure = createDocStructure("")
+        PageRedirects.redirectPageHtml(rootDocStructure, rootDocStructure.tableOfContents().index)
+                .should contain('url=/"')
+    }
+
+    @Test
+    void "deploys redirect stub for renamed page"() {
+        def docStructure = createDocStructure("product")
+
+        def tempDir = Files.createTempDirectory("znai-page-redirects")
+        def csvPath = tempDir.resolve("redirects.csv")
+        Files.writeString(csvPath, "old-chapter/old-page,chapter/pageOne\n")
+
+        def deployer = new Deployer(tempDir, tempDir.resolve("deploy"))
+        new PageRedirects(docStructure, deployer, csvPath).deployRedirectPages()
+
+        Files.readString(tempDir.resolve("deploy/old-chapter/old-page/index.html"))
+                .should contain('url=/product/chapter/pageOne/"')
+    }
+
+    private static WebSiteDocStructure createDocStructure(String docId) {
+        def docMeta = new DocMeta([:])
+        docMeta.setId(docId)
+
+        def toc = new TableOfContents("md")
+        toc.addTocItem("chapter", "pageOne")
+        toc.addTocItem("", "top-page")
+        toc.addIndex()
+
+        return new WebSiteDocStructure(TEST_COMPONENTS_REGISTRY, docMeta, toc, new MarkdownParsingConfiguration())
     }
 }

--- a/znai-website-gen/src/test/groovy/org/testingisdocumenting/znai/website/WebSiteDocStructureTest.groovy
+++ b/znai-website-gen/src/test/groovy/org/testingisdocumenting/znai/website/WebSiteDocStructureTest.groovy
@@ -84,6 +84,25 @@ class WebSiteDocStructureTest {
     }
 
     @Test
+    void "should create root based url without double slashes when doc id is empty"() {
+        def rootDocMeta = new DocMeta([:])
+        def rootDocStructure = new WebSiteDocStructure(TEST_COMPONENTS_REGISTRY, rootDocMeta, toc, new MarkdownParsingConfiguration())
+
+        def indexPath = Paths.get('/home/user/docs/index.md')
+        def path = Paths.get('/home/user/docs/chapter/pageOne.md')
+
+        rootDocStructure.createUrl(path, new DocUrl("/")).should == "/"
+        rootDocStructure.createUrl(path, new DocUrl("#anchor")).should == "/chapter/pageOne#anchor"
+        rootDocStructure.createUrl(path, new DocUrl("/#anchor")).should == "/#anchor"
+        rootDocStructure.createUrl(path, new DocUrl("test/page")).should == "/test/page"
+        rootDocStructure.createUrl(path, new DocUrl("test/page#anchor")).should == "/test/page#anchor"
+        rootDocStructure.createUrl(path, new DocUrl("test/page?key=value#anchor")).should == "/test/page?key=value#anchor"
+        rootDocStructure.createUrl(indexPath, new DocUrl("file-system/page")).should == "/file-system/page"
+        rootDocStructure.fullUrl("chapter/pageOne").should == "/chapter/pageOne"
+        rootDocStructure.fullUrl("").should == "/"
+    }
+
+    @Test
     void "should create url without double slashes when dirName is empty"() {
         def path = Paths.get('/home/user/docs/chapter/pageOne.md')
 


### PR DESCRIPTION
With `--doc-id ""` (site deployed at a domain root) internal urls were composed as `/<doc-id>/<dir>/<page>`, producing protocol-relative `//dir/page` references in page bodies, chapter index redirect stubs and `search-entries.xml` — browsers resolve those as a host named `dir` and leave the site. Empty doc-id now emits single-slash root-relative urls, matching the existing handling in `WebResource`, `HtmlPage` and `LlmContentGenerator`.

Redirect stubs also gain trailing-slash targets: the stub `<dir>/index.html` and the real page directory `<dir>/index/` collide at the extension-less url on hosts that resolve the file before the directory (e.g. GitHub Pages), so once the doubled slash is repaired the stub would redirect to itself in an infinite meta-refresh loop. The stub html is now built in one place shared by the chapter index and renamed-page redirects, which also repairs the doubled slash for top-level redirect targets and points redirects to the index page at the doc root.

Covered by new tests in `WebSiteDocStructureTest`, `ServerSideSimplifiedRendererTest` and `PageRedirectsTest` (including a deploy-to-temp-dir stub test). Verified end-to-end by deploying a doc with `--doc-id ""` and with a regular doc-id: the only change for non-empty doc-ids is the trailing slash in redirect targets.

Fixes #1575

Assisted-by: Claude:claude-fable-5