### PR TITLE
testing-examples: adapt image capture example to duckduckgo redesign

### DIFF
--- a/znai-testing-examples/examples/webtauexamples/imageCapture.groovy
+++ b/znai-testing-examples/examples/webtauexamples/imageCapture.groovy
@@ -2,7 +2,7 @@ package webtauexamples
 
 import static org.testingisdocumenting.webtau.WebTauGroovyDsl.*
 
-def homeSearchInput = $('input[class*="searchbox_input"], input[class*="search-input"]')
+def homeSearchInput = $('textarea[class*="search-input"], input[class*="searchbox_input"], input[class*="search-input"]')
 def resultSearchInput = $("#search_form_input")
 def result = $('article[data-testid="result"]')
 


### PR DESCRIPTION
The `capture screenshot (imageCapture.groovy)` webtau example fails on every CI run — including unrelated PRs such as the dependabot bump in run 32409696265 — because the duckduckgo homepage was redesigned: the search box is now a `<textarea class="search-input_searchInput__…">` inside the new AI searchbox, so the example's `input[class*="searchbox_input"], input[class*="search-input"]` selector matches nothing (the old `searchbox_input` id now sits on the chat box). Master still shows green only because `ci-build` last ran there at the 1.91 release.

This prepends `textarea[class*="search-input"]` to the selector list, keeping the old variants. Verified locally against live duckduckgo: the full flow passes — search submit via enter on the textarea, the results-page selectors (`#search_form_input`, `article[data-testid="result"]`) unchanged, and the annotated `duckduckgo-search` screenshot regenerates.

Unblocks CI for #1580 and any other open PR.

Assisted-by: Claude:claude-fable-5